### PR TITLE
Update MaterialDatePicker.java

### DIFF
--- a/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
+++ b/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
@@ -53,7 +53,7 @@ public class MaterialDatePicker extends FocusPanel{
 	}-*/;
 	
 	private static native void setDatePickerValue(String value)/*-{
-		$wnd.jQuery('.datepicker').val("value");
+		$wnd.jQuery('.datepicker').val(value);
 	}-*/;
 	
 	public static native void initDatePicker()/*-{


### PR DESCRIPTION
there was a simple bug on setDatePickerValue. the variable "value" was printed as a string.