### PR TITLE
Added Tap/Mouse event handlers for indication on ListItem within MaterialCollection

### DIFF
--- a/src/main/java/gwt/material/design/client/ui/MaterialCollection.java
+++ b/src/main/java/gwt/material/design/client/ui/MaterialCollection.java
@@ -20,10 +20,13 @@ package gwt.material.design.client.ui;
  * #L%
  */
 
+import java.util.Iterator;
+
 import gwt.material.design.client.custom.MaterialWidget;
 import gwt.material.design.client.resources.MaterialResources;
 
 import com.google.gwt.core.client.GWT;
+import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.uibinder.client.UiBinder;
 import com.google.gwt.uibinder.client.UiChild;
 import com.google.gwt.uibinder.client.UiField;
@@ -39,117 +42,195 @@ public class MaterialCollection extends MaterialWidget {
 	interface MaterialCollectionUiBinder extends UiBinder<Widget, MaterialCollection> {
 	}
 
-	@UiField 
+	@UiField
 	UnorderedList collection;
-	
+
 	public MaterialCollection() {
 		initWidget(uiBinder.createAndBindUi(this));
 	}
 
-	
-	
 	@Override
 	protected void onAttach() {
-		// TODO Auto-generated method stub
 		super.onAttach();
 		this.addStyleName(MaterialResources.INSTANCE.materialcss().collection());
 	}
 
-
-
 	/**
-	 * Add each item on a collection container
-	 * @param item the item to be added
+	 * Add new item on the collection container. Implicit as well assigns a
+	 * press indication.
+	 * 
+	 * @param item
+	 *            The widget to be added to the collection container
+	 * @return The created ListItem, this might be used to add DomHandlers (eg.
+	 *         ClickHandlers etc.) and to react therefore on the full widget
+	 *         panel
 	 */
 	@UiChild(tagname = "item")
-	public void addCollectionItem(Widget item){
-		ListItem list = new ListItem(item);
-		list.addStyleName("collection-item");
-		collection.add(list);
+	public ListItem addCollectionItem(Widget item) {
+		ListItem listItem = new ListItem(item);
+		listItem.addStyleName("collection-item");
+		MaterialUiHelper.addMousePressedHandlers(listItem);
+		collection.add(listItem);
+		return listItem;
 	}
 
-    public void insertCollectionItem(Widget item, int beforeIndex) {
-        ListItem list = new ListItem(item);
-        list.addStyleName("collection-item");
-        collection.insert(list, beforeIndex);
-    }
-	
+	/**
+	 * Insert item on a collection container at the given index. Implicit as
+	 * well assigns a press indication.
+	 * 
+	 * @param item
+	 *            The widget to be inserted into the collection container
+	 * @param beforeIndex
+	 *            The location to insert the widget into the collection
+	 * @return The created ListItem, this might be used to add DomHandlers (eg.
+	 *         ClickHandlers etc.) and to react therefore on the full widget
+	 *         panel
+	 */
+	public ListItem insertCollectionItem(Widget item, int beforeIndex) {
+		ListItem listItem = new ListItem(item);
+		listItem.addStyleName("collection-item");
+		MaterialUiHelper.addMousePressedHandlers(listItem);
+		collection.insert(listItem, beforeIndex);
+		return listItem;
+	}
+
+	/**
+	 * Adds an item to the collection styled as header row. No PressedHandler/Indication is
+	 * applied here.
+	 * 
+	 * @param item The widget to be added to the put at the top of the collection container
+	 * @return The created ListItem, this might be used to add DomHandlers (eg.
+	 *         ClickHandlers etc.) and to react therefore on the full widget
+	 *         panel
+	 */
 	@UiChild(tagname = "header")
-	public void addHeader(Widget item){
-		ListItem list = new ListItem(item);
-		list.addStyleName(MaterialResources.INSTANCE.materialcss().collectionHeader());
-		collection.add(list);
-	}
-	
-	@UiChild(tagname = "dismissable")
-	public void addDismissableItem(Widget item){
-		ListItem list = new ListItem(item);
-		list.addStyleName("collection-item dismissable");
-		collection.add(list);
+	public ListItem addHeader(Widget item) {
+		ListItem listItem = new ListItem(item);
+		listItem.addStyleName(MaterialResources.INSTANCE.materialcss().collectionHeader());
+		collection.add(listItem);
+		return listItem;
 	}
 
-    public void insertDismissableItem(Widget item, int beforeIndex) {
-        ListItem list = new ListItem(item);
-        list.addStyleName("collection-item dismissable");
-        collection.insert(list, beforeIndex);
-    }
-	
+	/**
+	 * Add new dismissable item on the collection container. Implicit as well
+	 * assigns a press indication.
+	 * 
+	 * @param item
+	 *            The widget item to be added
+	 * @return The created ListItem, this might be used to add DomHandlers (eg.
+	 *         ClickHandlers etc.) and to react therefore on the full widget
+	 *         panel
+	 */
+	@UiChild(tagname = "dismissable")
+	public ListItem addDismissableItem(Widget item) {
+		ListItem listItem = new ListItem(item);
+		listItem.addStyleName("collection-item dismissable");
+		MaterialUiHelper.addMousePressedHandlers(listItem);
+		collection.add(listItem);
+		return listItem;
+	}
+
+	/**
+	 * Insert new item on the collection container. Implicit as well assigns a
+	 * press indication.
+	 * 
+	 * @param item
+	 *            The widget item to be inserted
+	 * @param beforeIndex
+	 *            The location to be inserted
+	 * @return The created ListItem, this might be used to add DomHandlers (eg.
+	 *         ClickHandlers etc.) and to react therefore on the full widget
+	 *         panel
+	 */
+	public ListItem insertDismissableItem(Widget item, int beforeIndex) {
+		ListItem listItem = new ListItem(item);
+		listItem.addStyleName("collection-item dismissable");
+		MaterialUiHelper.addMousePressedHandlers(listItem);
+		collection.insert(listItem, beforeIndex);
+		return listItem;
+	}
+
+	/**
+	 * Add new Avatar item on the collection container. Implicit as well assigns
+	 * a press indication.
+	 * 
+	 * @param item
+	 *            The widget item to be added
+	 * @return The created ListItem, this might be used to add DomHandlers (eg.
+	 *         ClickHandlers etc.) and to react therefore on the full widget
+	 *         panel
+	 */
 	@UiChild(tagname = "avatar")
-	public void addAvatarItem(Widget item){
-		ListItem list = new ListItem(item);
-		list.addStyleName("collection-item avatar");
-		collection.add(list);
-		if(item instanceof MaterialPanel){
+	public ListItem addAvatarItem(Widget item) {
+		ListItem listItem = new ListItem(item);
+		listItem.addStyleName("collection-item avatar");
+		MaterialUiHelper.addMousePressedHandlers(listItem);
+		collection.add(listItem);
+		if (item instanceof MaterialPanel) {
 			HTMLPanel panel = (HTMLPanel) item;
-			for(Widget w : panel){
-				if(w instanceof MaterialIcon){
+			for (Widget w : panel) {
+				if (w instanceof MaterialIcon) {
 					w.addStyleName("secondary-content");
 				}
 			}
 		}
+		return listItem;
 	}
 
-    public void insertAvatarItem(Widget item, int beforeIndex) {
-        ListItem list = new ListItem(item);
-        list.addStyleName("collection-item avatar");
-        collection.insert(list, beforeIndex);
-        if (item instanceof MaterialPanel) {
-            HTMLPanel panel = (HTMLPanel) item;
-            for (Widget w : panel) {
-                if (w instanceof MaterialIcon) {
-                    w.addStyleName("secondary-content");
-                }
-            }
-        }
-    }
-	
-	public void clear(){
+	/**
+	 * Insert new Avatar item on the collection container. Implicit as well
+	 * assigns a press indication.
+	 * 
+	 * @param item
+	 *            The item to be added
+	 * @param beforeIndex
+	 *            The location to insert the widget item
+	 * @return The created ListItem, this might be used to add DomHandlers (eg.
+	 *         ClickHandlers etc.) and to react therefore on the full widget
+	 *         panel
+	 */
+	public ListItem insertAvatarItem(Widget item, int beforeIndex) {
+		ListItem listItem = new ListItem(item);
+		listItem.addStyleName("collection-item avatar");
+		MaterialUiHelper.addMousePressedHandlers(listItem);
+		collection.insert(listItem, beforeIndex);
+		if (item instanceof MaterialPanel) {
+			HTMLPanel panel = (HTMLPanel) item;
+			for (Widget w : panel) {
+				if (w instanceof MaterialIcon) {
+					w.addStyleName("secondary-content");
+				}
+			}
+		}
+		return listItem;
+	}
+
+	public void clear() {
 		collection.clear();
 	}
 
-    public Widget getWidget(int index) {
-        return getFirstChild(collection.getWidget(index));
-    }
+	public Widget getWidget(int index) {
+		return getFirstChild(collection.getWidget(index));
+	}
 
-    public int getWidgetCount() {
-        return collection.getWidgetCount();
-    }
+	public int getWidgetCount() {
+		return collection.getWidgetCount();
+	}
 
-    public int getWidgetIndex(Widget child) {
-        return collection.getWidgetIndex(child.getParent());
-    }
+	public int getWidgetIndex(Widget child) {
+		return collection.getWidgetIndex(child.getParent());
+	}
 
-    public int getWidgetIndex(IsWidget child) {
-        return getWidgetIndex(asWidgetOrNull(child).getParent());
-    }
+	public int getWidgetIndex(IsWidget child) {
+		return getWidgetIndex(asWidgetOrNull(child).getParent());
+	}
 
-    private Widget getFirstChild(Widget parent) {
-        if (parent instanceof HasWidgets) {
-            Iterator<Widget> iter = ((HasWidgets) parent).iterator();
-            return (iter != null && iter.hasNext()) ? iter.next() : null;
-        }
-
-        return null;
-    }
+	private Widget getFirstChild(Widget parent) {
+		if (parent instanceof HasWidgets) {
+			Iterator<Widget> iter = ((HasWidgets) parent).iterator();
+			return (iter != null && iter.hasNext()) ? iter.next() : null;
+		}
+		return null;
+	}
 
 }

--- a/src/main/java/gwt/material/design/client/ui/MaterialUiHelper.java
+++ b/src/main/java/gwt/material/design/client/ui/MaterialUiHelper.java
@@ -1,0 +1,118 @@
+package gwt.material.design.client.ui;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2015 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import com.google.gwt.event.dom.client.MouseDownEvent;
+import com.google.gwt.event.dom.client.MouseDownHandler;
+import com.google.gwt.event.dom.client.MouseOutEvent;
+import com.google.gwt.event.dom.client.MouseOutHandler;
+import com.google.gwt.event.dom.client.MouseUpEvent;
+import com.google.gwt.event.dom.client.MouseUpHandler;
+import com.google.gwt.event.dom.client.TouchCancelEvent;
+import com.google.gwt.event.dom.client.TouchCancelHandler;
+import com.google.gwt.event.dom.client.TouchEndEvent;
+import com.google.gwt.event.dom.client.TouchEndHandler;
+import com.google.gwt.event.dom.client.TouchStartEvent;
+import com.google.gwt.event.dom.client.TouchStartHandler;
+import com.google.gwt.user.client.Event;
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ *  This static helper class is supposed to collect common methods used for multiple kind of UI classes.
+ *  It is defined as abstract to prohibit 
+ *
+ */
+public final class MaterialUiHelper {
+
+	private static String PRESSED_CSS_STYLE_NAME = "pressed";
+
+	/**
+	 * Adds a mouse pressed handler to a widget. Adds a CSS style ('pressed',
+	 * {@link #PRESSED_CSS_STYLE_NAME}) to the widget as long as the mouse is
+	 * pressed (or the user touches the widget). See
+	 * {@link #addMousePressedHandlers(Widget, String)}.
+	 *
+	 * @param widget The widget to which the "pressed" style musst be applied
+	 */
+	public static void addMousePressedHandlers(final Widget widget) {
+		addMousePressedHandlers(widget, PRESSED_CSS_STYLE_NAME);
+	}
+
+	/**
+	 * Adds a mouse pressed handler to a widget. Adds a CSS style to the widget
+	 * as long as the mouse is pressed (or the user touches the widget on mobile browser).
+	 *
+	 * @param widget The widget to which the style must be applied for mouse/touch event
+	 * @param cssStyleName CSS style name to be applied
+	 */
+	public static void addMousePressedHandlers(final Widget widget, final String cssStyleName) {
+		widget.sinkEvents(Event.ONMOUSEDOWN);
+		widget.sinkEvents(Event.ONMOUSEUP);
+		widget.sinkEvents(Event.ONMOUSEOUT);
+		widget.sinkEvents(Event.TOUCHEVENTS);
+
+		widget.addHandler(new MouseDownHandler() {
+			@Override
+			public void onMouseDown(MouseDownEvent event) {
+				widget.addStyleName(cssStyleName);
+			}
+		}, MouseDownEvent.getType());
+
+		widget.addHandler(new MouseUpHandler() {
+			@Override
+			public void onMouseUp(MouseUpEvent event) {
+				widget.removeStyleName(cssStyleName);
+			}
+		}, MouseUpEvent.getType());
+
+		widget.addHandler(new MouseOutHandler() {
+			@Override
+			public void onMouseOut(MouseOutEvent event) {
+				widget.removeStyleName(cssStyleName);
+			}
+		}, MouseOutEvent.getType());
+
+		// Touch Events
+		widget.addHandler(new TouchStartHandler() {
+			@Override
+			public void onTouchStart(TouchStartEvent event) {
+				widget.addStyleName(cssStyleName);
+			}
+		}, TouchStartEvent.getType());
+
+		widget.addHandler(new TouchEndHandler() {
+			@Override
+			public void onTouchEnd(TouchEndEvent event) {
+				widget.removeStyleName(cssStyleName);
+
+			}
+		}, TouchEndEvent.getType());
+
+		widget.addHandler(new TouchCancelHandler() {
+			@Override
+			public void onTouchCancel(TouchCancelEvent event) {
+				widget.removeStyleName(cssStyleName);
+			}
+		}, TouchCancelEvent.getType());
+	}
+
+}

--- a/src/main/resources/gwt/material/design/client/resources/materialcss.gss
+++ b/src/main/resources/gwt/material/design/client/resources/materialcss.gss
@@ -1,3 +1,4 @@
+
 * html,body {
 	margin: 0px;
 	padding: 0px;
@@ -185,5 +186,10 @@ th{
 	-moz-box-shadow: none !important;
 }
 
+@external pressed;
+.pressed{
+	background-color: #ebe4d1 !important;
+	background-image: none;
+}
 
 

--- a/src/main/resources/gwt/material/design/client/resources/materialmobilecss.gss
+++ b/src/main/resources/gwt/material/design/client/resources/materialmobilecss.gss
@@ -1,3 +1,9 @@
+* {
+	/* Remove the blue tap-color on android/webkit */
+	-webkit-tap-highlight-color: rgba(0, 0, 0, 0) !important;
+	-webkit-focus-ring-color: rgba(0, 0, 0, 0) !important;
+}
+
 .loginPanel {
 	width: 90% !important;
 }


### PR DESCRIPTION
- Added Helper Class for various UI static stuff
- Added Tap/Mouse events for action indication on MaterialCollection ListItems
- Return ListItem in order to allow the caller to treat mouse events on the full listitem (not only on the widget given.
- Fixed missing Import bug on MaterialCollection from actual master