### PR TITLE
setDate was commented out, picker.set('select') with fixed date?

### DIFF
--- a/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
+++ b/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
@@ -109,7 +109,7 @@ public class MaterialDatePicker extends FocusPanel{
         var input = $wnd.jQuery('#' + id).pickadate();
         var picker = input.pickadate('picker');
 		if(picker) {
-			picker.set('select', 1429970887654);
+			picker.set('select', value);
 		}
 	}-*/;
 	
@@ -165,8 +165,8 @@ public class MaterialDatePicker extends FocusPanel{
 		this.date = date;
 		DateTimeFormat sdf = DateTimeFormat.getFormat("d MMM, yyyy");
 		setDatePickerValue(sdf.format(date), id);
-		/*DateTimeFormat sdfSetter = DateTimeFormat.getFormat("yyyy-MM-dd");
-		selectDate(sdfSetter.format(date), id, this);*/
+		DateTimeFormat sdfSetter = DateTimeFormat.getFormat("yyyy-MM-dd");
+		selectDate(sdfSetter.format(date), id, this);
 	}
 	
 	private native void selectDate(String date, String id, MaterialDatePicker parent) /*-{


### PR DESCRIPTION
I removed the comments on the original changes to allow setting the pickers date and to avoid preset fixed date of 25.April. Why were this lines commented?

Cheers,
Stefan