### PR TITLE
enable use with GWT 2.8

### DIFF
--- a/src/main/resources/gwt/material/design/GwtMaterialDesign.gwt.xml
+++ b/src/main/resources/gwt/material/design/GwtMaterialDesign.gwt.xml
@@ -26,6 +26,8 @@
 <!DOCTYPE module PUBLIC "-//Google Inc.//DTD Google Web Toolkit 2.7.0//EN"
         "http://gwtproject.org/doctype/2.7.0/gwt-module.dtd">
 <module>
+    <set-configuration-property name="CssResource.conversionMode"    value="strict" />
+
     <!-- Inherit the core Web Toolkit stuff.                        -->
     <inherits name='com.google.gwt.user.User'/>
     <inherits name="com.google.gwt.core.Core"/>


### PR DESCRIPTION
In GWT 2.8 CssResource.enableGss is true by default.
