### PR TITLE
Material Modal now implements HasCloseHandlers, and MaterialAutoComplete is even more generic.

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialAutoComplete.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialAutoComplete.java
@@ -15,7 +15,6 @@ package gwt.material.design.client.ui;
 
 import gwt.material.design.client.base.HasError;
 import gwt.material.design.client.base.HasPlaceholder;
-import gwt.material.design.client.base.MaterialSuggestionOracle;
 import gwt.material.design.client.base.MaterialWidget;
 import gwt.material.design.client.base.mixin.ErrorMixin;
 import gwt.material.design.client.constants.IconType;
@@ -43,7 +42,6 @@ import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.FlowPanel;
 import com.google.gwt.user.client.ui.HasValue;
-import com.google.gwt.user.client.ui.MultiWordSuggestOracle;
 import com.google.gwt.user.client.ui.SuggestBox;
 import com.google.gwt.user.client.ui.SuggestOracle;
 import com.google.gwt.user.client.ui.SuggestOracle.Suggestion;
@@ -52,8 +50,9 @@ import com.google.gwt.user.client.ui.Widget;
 
 // @formatter:off
 /**
- * Use GWT Autocomplete to search for matches from local or remote data sources. We used
- * MultiWordSuggestOracle to populate the list to be added on the autocomplete values.
+ * Use GWT Autocomplete to search for matches from local or remote data sources.
+ * We used MultiWordSuggestOracle to populate the list to be added on the
+ * autocomplete values.
  *
  * <h3>UiBinder Usage:</h3>
  * 
@@ -63,18 +62,19 @@ import com.google.gwt.user.client.ui.Widget;
  * </pre>
  *
  * @author kevzlou7979
- * @see <a href="http://gwt-material-demo.herokuapp.com/#autocompletes">Material AutoComplete</a>
+ * @see <a href="http://gwt-material-demo.herokuapp.com/#autocompletes">Material
+ *      AutoComplete</a>
  */
 // @formatter:on
 public class MaterialAutoComplete extends MaterialWidget implements HasError, HasPlaceholder,
-        HasValue<List<? extends Suggestion>> {
+    HasValue<List<? extends Suggestion>> {
 
     private Map<Suggestion, MaterialChip> suggestionMap = new LinkedHashMap<>();
 
     private List<ListItem> itemsHighlighted = new ArrayList<>();
     private FlowPanel panel = new FlowPanel();
     private UnorderedList list = new UnorderedList();
-    private MultiWordSuggestOracle suggestions;
+    private SuggestOracle suggestions;
     private TextBox itemBox = new TextBox();
     private int limit = 0;
     private MaterialLabel lblError = new MaterialLabel();
@@ -83,19 +83,23 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
     private MaterialChipProvider chipProvider = new DefaultMaterialChipProvider();
 
     private final ErrorMixin<MaterialAutoComplete, MaterialLabel> errorMixin = new ErrorMixin<>(this,
-          lblError, list);
+        lblError, list);
 
     /**
-     * Use MaterialAutocomplete to search for matches from local or remote data sources.
+     * Use MaterialAutocomplete to search for matches from local or remote data
+     * sources.
      */
     public MaterialAutoComplete() {
         initWidget(panel);
     }
 
     /**
-     * Use MaterialAutocomplete to search for matches from local or remote data sources.
+     * Use MaterialAutocomplete to search for matches from local or remote data
+     * sources.
+     * 
+     * @see #setSuggestions(SuggestOracle)
      */
-    public MaterialAutoComplete(MaterialSuggestionOracle suggestions) {
+    public MaterialAutoComplete(SuggestOracle suggestions) {
         initWidget(panel);
         generateAutoComplete(suggestions);
     }
@@ -103,7 +107,7 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
     /**
      * Generate and build the List Items to be set on Auto Complete box.
      */
-    private void generateAutoComplete(MaterialSuggestionOracle suggestions) {
+    private void generateAutoComplete(SuggestOracle suggestions) {
         list.setStyleName("multiValueSuggestBox-list");
         this.suggestions = suggestions;
         final ListItem item = new ListItem();
@@ -121,47 +125,26 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
                 boolean itemsChanged = false;
 
                 switch (event.getNativeKeyCode()) {
-                    case KeyCodes.KEY_ENTER:
-                        if (directInputAllowed) {
-                            String value = itemBox.getValue();
-                            if (value != null && !(value = value.trim()).isEmpty()) {
-                                gwt.material.design.client.base.Suggestion directInput =
-                                        new gwt.material.design.client.base.Suggestion();
-                                directInput.setDisplay(value);
-                                directInput.setSuggestion(value);
-                                itemsChanged = addItem(directInput);
-                                itemBox.setValue("");
-                                itemBox.setFocus(true);
-                            }
+                case KeyCodes.KEY_ENTER:
+                    if (directInputAllowed) {
+                        String value = itemBox.getValue();
+                        if (value != null && !(value = value.trim()).isEmpty()) {
+                            gwt.material.design.client.base.Suggestion directInput = new gwt.material.design.client.base.Suggestion();
+                            directInput.setDisplay(value);
+                            directInput.setSuggestion(value);
+                            itemsChanged = addItem(directInput);
+                            itemBox.setValue("");
+                            itemBox.setFocus(true);
                         }
-                        break;
+                    }
+                    break;
 
-                    case KeyCodes.KEY_BACKSPACE:
-                        if (itemBox.getValue().trim().isEmpty()) {
-                            if (itemsHighlighted.isEmpty()) {
-                                if (suggestionMap.size() > 0) {
+                case KeyCodes.KEY_BACKSPACE:
+                    if (itemBox.getValue().trim().isEmpty()) {
+                        if (itemsHighlighted.isEmpty()) {
+                            if (suggestionMap.size() > 0) {
 
-                                    ListItem li = (ListItem) list.getWidget(list.getWidgetCount() - 2);
-                                    MaterialChip p = (MaterialChip) li.getWidget(0);
-
-                                    Set<Entry<Suggestion, MaterialChip>> entrySet = suggestionMap.entrySet();
-                                    for (Entry<Suggestion, MaterialChip> entry : entrySet) {
-                                        if (p.equals(entry.getValue())) {
-                                            suggestionMap.remove(entry.getKey());
-                                            itemsChanged = true;
-                                            break;
-                                        }
-                                    }
-
-                                    list.remove(li);
-                                }
-                            }
-                        }
-
-                    case KeyCodes.KEY_DELETE:
-                        if (itemBox.getValue().trim().isEmpty()) {
-                            for (ListItem li : itemsHighlighted) {
-                                li.removeFromParent();
+                                ListItem li = (ListItem) list.getWidget(list.getWidgetCount() - 2);
                                 MaterialChip p = (MaterialChip) li.getWidget(0);
 
                                 Set<Entry<Suggestion, MaterialChip>> entrySet = suggestionMap.entrySet();
@@ -172,11 +155,31 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
                                         break;
                                     }
                                 }
+
+                                list.remove(li);
                             }
-                            itemsHighlighted.clear();
                         }
-                        itemBox.setFocus(true);
-                        break;
+                    }
+
+                case KeyCodes.KEY_DELETE:
+                    if (itemBox.getValue().trim().isEmpty()) {
+                        for (ListItem li : itemsHighlighted) {
+                            li.removeFromParent();
+                            MaterialChip p = (MaterialChip) li.getWidget(0);
+
+                            Set<Entry<Suggestion, MaterialChip>> entrySet = suggestionMap.entrySet();
+                            for (Entry<Suggestion, MaterialChip> entry : entrySet) {
+                                if (p.equals(entry.getValue())) {
+                                    suggestionMap.remove(entry.getKey());
+                                    itemsChanged = true;
+                                    break;
+                                }
+                            }
+                        }
+                        itemsHighlighted.clear();
+                    }
+                    itemBox.setFocus(true);
+                    break;
                 }
 
                 if (itemsChanged) {
@@ -205,7 +208,7 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
 
         panel.add(list);
         panel.getElement().setAttribute("onclick",
-                "document.getElementById('" + autocompleteId + "').focus()");
+            "document.getElementById('" + autocompleteId + "').focus()");
         panel.add(lblError);
         box.setFocus(true);
     }
@@ -290,7 +293,8 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
     }
 
     /**
-     * @param itemValues the itemsSelected to set
+     * @param itemValues
+     *            the itemsSelected to set
      * @see #setValue(List)
      */
     public void setItemValues(List<String> itemValues) {
@@ -314,23 +318,28 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
     }
 
     /**
-     * @param itemsHighlighted the itemsHighlighted to set
+     * @param itemsHighlighted
+     *            the itemsHighlighted to set
      */
     public void setItemsHighlighted(List<ListItem> itemsHighlighted) {
         this.itemsHighlighted = itemsHighlighted;
     }
 
     /**
-     * @return the suggestions
+     * @return the suggestion oracle
      */
-    public MultiWordSuggestOracle getSuggestions() {
+    public SuggestOracle getSuggestions() {
         return suggestions;
     }
 
     /**
-     * @param suggestions the suggestions to set
+     * Sets the SuggestOracle to be used to provide suggestions. Also setups the
+     * component with the needed event handlers and UI elements.
+     * 
+     * @param suggestions
+     *            the suggestion oracle to set
      */
-    public void setSuggestions(MaterialSuggestionOracle suggestions) {
+    public void setSuggestions(SuggestOracle suggestions) {
         this.suggestions = suggestions;
         generateAutoComplete(suggestions);
     }
@@ -369,57 +378,63 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
     }
 
     /**
-     * Gets the current {@link MaterialChipProvider}. By default, the class uses an instance of
-     * {@link DefaultMaterialChipProvider}.
+     * Gets the current {@link MaterialChipProvider}. By default, the class uses
+     * an instance of {@link DefaultMaterialChipProvider}.
      */
     public MaterialChipProvider getChipProvider() {
         return chipProvider;
     }
 
     /**
-     * Sets a {@link MaterialChipProvider} that can customize how the {@link MaterialChip} is created
-     * for each selected {@link Suggestion}.
+     * Sets a {@link MaterialChipProvider} that can customize how the
+     * {@link MaterialChip} is created for each selected {@link Suggestion}.
      */
     public void setChipProvider(MaterialChipProvider chipProvider) {
         this.chipProvider = chipProvider;
     }
 
     /**
-     * When set to <code>false</code>, only {@link Suggestion}s from the SuggestionOracle are
-     * accepted. Direct input create by the user is ignored. By default, direct input is allowed.
+     * When set to <code>false</code>, only {@link Suggestion}s from the
+     * SuggestionOracle are accepted. Direct input create by the user is
+     * ignored. By default, direct input is allowed.
      */
     public void setDirectInputAllowed(boolean directInputAllowed) {
         this.directInputAllowed = directInputAllowed;
     }
 
     /**
-     * @return if {@link Suggestion}s created by direct input from the user should be allowed. By
-     *         default directInputAllowed is <code>true</code>.
+     * @return if {@link Suggestion}s created by direct input from the user
+     *         should be allowed. By default directInputAllowed is
+     *         <code>true</code>.
      */
     public boolean isDirectInputAllowed() {
         return directInputAllowed;
     }
 
     /**
-     * Interface that defines how a {@link MaterialChip} is created, given a {@link Suggestion}.
+     * Interface that defines how a {@link MaterialChip} is created, given a
+     * {@link Suggestion}.
      * 
      * @see MaterialAutoComplete#setChipProvider(MaterialChipProvider)
      */
     public static interface MaterialChipProvider {
 
         /**
-         * Creates and returns a {@link MaterialChip} based on the selected {@link Suggestion}.
+         * Creates and returns a {@link MaterialChip} based on the selected
+         * {@link Suggestion}.
          * 
-         * @param suggestion the selected {@link Suggestion}
+         * @param suggestion
+         *            the selected {@link Suggestion}
          * 
-         * @return the created MaterialChip, or <code>null</code> if the suggestion should be ignored.
+         * @return the created MaterialChip, or <code>null</code> if the
+         *         suggestion should be ignored.
          */
         MaterialChip getChip(Suggestion suggestion);
     }
 
     /**
-     * Default implementation of the {@link MaterialChipProvider} interface, used by the
-     * {@link MaterialAutoComplete}.
+     * Default implementation of the {@link MaterialChipProvider} interface,
+     * used by the {@link MaterialAutoComplete}.
      * 
      * @see MaterialAutoComplete#setChipProvider(MaterialChipProvider)
      */
@@ -446,17 +461,16 @@ public class MaterialAutoComplete extends MaterialWidget implements HasError, Ha
     }
 
     @Override
-    public HandlerRegistration addValueChangeHandler(
-            ValueChangeHandler<List<? extends Suggestion>> handler) {
+    public HandlerRegistration addValueChangeHandler(ValueChangeHandler<List<? extends Suggestion>> handler) {
         return addHandler(handler, ValueChangeEvent.getType());
     }
 
     /**
-     * Returns the selected {@link Suggestion}s. Modifications to the list are not propagated to the
-     * component.
+     * Returns the selected {@link Suggestion}s. Modifications to the list are
+     * not propagated to the component.
      * 
-     * @return the list of selected {@link Suggestion}s, or empty if none was selected (never
-     *         <code>null</code>).
+     * @return the list of selected {@link Suggestion}s, or empty if none was
+     *         selected (never <code>null</code>).
      */
     @Override
     public List<? extends Suggestion> getValue() {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
@@ -33,7 +33,6 @@ import com.google.gwt.event.logical.shared.CloseEvent;
 import com.google.gwt.event.logical.shared.CloseHandler;
 import com.google.gwt.event.logical.shared.HasCloseHandlers;
 import com.google.gwt.event.shared.HandlerRegistration;
-import com.google.gwt.user.client.ui.RootPanel;
 
 //@formatter:off
 
@@ -95,11 +94,28 @@ public class MaterialModal extends ComplexWidget implements HasType<ModalType>, 
 
     /**
      * Open the modal programatically
+     * 
+     * <p>
+     * Note: the MaterialModal component must be added to the document before
+     * calling this method. When declaring this modal on a UiBinder file, the
+     * MaterialModal is already added, but if you call it using pure Java, you
+     * must add it to a container before opening the modal. You can do it by
+     * calling, for example:
+     * </p>
+     * 
+     * <pre>
+     * MaterialModal modal = new MaterialModal();
+     * RootPanel.get().add(modal);
+     * </pre>
+     * 
+     * @throws IllegalStateException
+     *             If the MaterialModal is not added to the document
      */
     public void openModal() {
         // the modal must be added to the document before opening
         if (this.getParent() == null) {
-            RootPanel.get().add(this);
+            throw new IllegalStateException(
+                "The MaterialModal must be added to the document before calling openModal().");
         }
         openModal(getElement(), opacity, dismissable, inDuration, outDuration);
     }
@@ -130,14 +146,16 @@ public class MaterialModal extends ComplexWidget implements HasType<ModalType>, 
     }-*/;
 
     private void onNativeClose(boolean autoClosed) {
-        // removes from the document after closing the modal window
-        this.removeFromParent();
         CloseEvent.fire(this, this, autoClosed);
     }
 
     /**
      * Close the modal programatically. It is the same as calling
      * {@link #closeModal(boolean)} with <code>false</code> as parameter.
+     * <p>
+     * Note: you may need to remove it MaterialModal from the document if you
+     * are not using UiBinder. See {@link #openModal()}.
+     * </p>
      * 
      */
     public void closeModal() {
@@ -146,6 +164,10 @@ public class MaterialModal extends ComplexWidget implements HasType<ModalType>, 
 
     /**
      * Close the modal programatically.
+     * <p>
+     * Note: you may need to remove it MaterialModal from the document if you
+     * are not using UiBinder. See {@link #openModal()}.
+     * </p>
      * 
      * @param autoClosed
      *            Flag indicating if the modal was automatically dismissed

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
@@ -20,23 +20,27 @@ package gwt.material.design.client.ui;
  * #L%
  */
 
-import com.google.gwt.core.client.Scheduler;
+import gwt.material.design.client.base.ComplexWidget;
+import gwt.material.design.client.base.HasDismissable;
+import gwt.material.design.client.base.HasTransition;
+import gwt.material.design.client.base.HasType;
+import gwt.material.design.client.base.mixin.CssTypeMixin;
+import gwt.material.design.client.constants.ModalType;
+
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
-import com.google.gwt.user.client.Command;
-import com.google.gwt.user.client.ui.HTMLPanel;
+import com.google.gwt.event.logical.shared.CloseEvent;
+import com.google.gwt.event.logical.shared.CloseHandler;
+import com.google.gwt.event.logical.shared.HasCloseHandlers;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.RootPanel;
-import com.google.gwt.user.client.ui.Widget;
-import gwt.material.design.client.base.*;
-import gwt.material.design.client.base.mixin.CssTypeMixin;
-import gwt.material.design.client.constants.CssType;
-import gwt.material.design.client.constants.ModalType;
-import gwt.material.design.client.constants.Type;
 
 //@formatter:off
 
 /**
- * Dialogs are content that are not original visible on a page but show up with extra information if needed. The transitions should make the appearance of the dialog make sense and not jarring to the user.
+ * Dialogs are content that are not original visible on a page but show up with
+ * extra information if needed. The transitions should make the appearance of
+ * the dialog make sense and not jarring to the user.
  *
  *
  * <p>
@@ -44,33 +48,39 @@ import gwt.material.design.client.constants.Type;
  *
  * <pre>
  * {@code
-<m:MaterialModal ui:field="modal" type="FIXED_FOOTER" dismissable="true" inDuration="500" outDuration="800">
-    <m:MaterialModalContent>
-        <m:MaterialTitle title="Title" description="Description" />
-    </m:MaterialModalContent>
-    <m:MaterialModalFooter>
-        <m:MaterialButton text="Close Modal" type="FLAT"/>
-    </m:MaterialModalFooter>
-</m:MaterialModal>
-}
+ * <m:MaterialModal ui:field="modal" type="FIXED_FOOTER" dismissable="true" inDuration="500" outDuration="800">
+ *     <m:MaterialModalContent>
+ *         <m:MaterialTitle title="Title" description="Description" />
+ *     </m:MaterialModalContent>
+ *     <m:MaterialModalFooter>
+ *         <m:MaterialButton text="Close Modal" type="FLAT"/>
+ *     </m:MaterialModalFooter>
+ * </m:MaterialModal>
+ * }
  * </pre>
  *
- * * <h3>Java Usage:</h3>
+ * *
+ * <h3>Java Usage:</h3>
  *
  * <pre>
- * {@code
-@UiField MaterialModal modal;
-modal.openModal();
-}
+ * {
+ *     &#064;code
+ *     &#064;UiField
+ *     MaterialModal modal;
+ *     modal.openModal();
+ * }
  * </pre>
+ * 
  * </p>
  *
  * @author kevzlou7979
  * @author Ben Dol
- * @see <a href="http://gwt-material-demo.herokuapp.com/#dialogs">Material Modals</a>
+ * @see <a href="http://gwt-material-demo.herokuapp.com/#dialogs">Material
+ *      Modals</a>
  */
-//@formatter:on
-public class MaterialModal extends ComplexWidget implements HasType<ModalType>, HasTransition, HasDismissable {
+// @formatter:on
+public class MaterialModal extends ComplexWidget implements HasType<ModalType>, HasTransition,
+    HasDismissable, HasCloseHandlers<MaterialModal> {
 
     private final CssTypeMixin<ModalType, MaterialModal> typeMixin = new CssTypeMixin<>(this);
     private int inDuration = 300;
@@ -83,44 +93,74 @@ public class MaterialModal extends ComplexWidget implements HasType<ModalType>, 
         setStyleName("modal");
     }
 
-    @Override
-    protected void onLoad() {
-        super.onLoad();
-    }
-
     /**
      * Open the modal programatically
      */
     public void openModal() {
-        openModal(getElement(),opacity, dismissable, inDuration, outDuration);
+        // the modal must be added to the document before opening
+        if (this.getParent() == null) {
+            RootPanel.get().add(this);
+        }
+        openModal(getElement(), opacity, dismissable, inDuration, outDuration);
     }
 
     /**
      * Open modal with additional properties
-     * @param e - Modal Component
-     * @param opacity - Opacity of modal background
-     * @param dismissable - Modal can be dismissed by clicking outside of the modal
-     * @param inDuration - Transition in Duration
-     * @param outDuration - Transition out Duration
+     * 
+     * @param e
+     *            - Modal Component
+     * @param opacity
+     *            - Opacity of modal background
+     * @param dismissable
+     *            - Modal can be dismissed by clicking outside of the modal
+     * @param inDuration
+     *            - Transition in Duration
+     * @param outDuration
+     *            - Transition out Duration
      */
-    private native void openModal(Element e,double opacity, boolean dismissable, int inDuration, int outDuration) /*-{
+    private native void openModal(Element e, double opacity, boolean dismissable, int inDuration, int outDuration) /*-{
+        var obj = this;
         $wnd.jQuery(e).openModal({
             opacity: opacity,
             dismissible: dismissable,
             in_duration: inDuration,
-            out_duration: outDuration
+            out_duration: outDuration,
+            complete: function () { obj.@gwt.material.design.client.ui.MaterialModal::onNativeClose(Z)(true); }
         });
     }-*/;
 
-    /**
-     * Close the modal programatically
-     */
-    public void closeModal() {
-        closeModal(getElement());
+    private void onNativeClose(boolean autoClosed) {
+        // removes from the document after closing the modal window
+        this.removeFromParent();
+        CloseEvent.fire(this, this, autoClosed);
     }
 
-    private native void closeModal(Element e) /*-{
-        $wnd.jQuery(e).closeModal();
+    /**
+     * Close the modal programatically. It is the same as calling
+     * {@link #closeModal(boolean)} with <code>false</code> as parameter.
+     * 
+     */
+    public void closeModal() {
+        closeModal(false);
+    }
+
+    /**
+     * Close the modal programatically.
+     * 
+     * @param autoClosed
+     *            Flag indicating if the modal was automatically dismissed
+     * 
+     * @see CloseEvent
+     */
+    public void closeModal(boolean autoClosed) {
+        closeModal(getElement(), autoClosed);
+    }
+
+    private native void closeModal(Element e, boolean autoClosed) /*-{
+        var obj = this;
+        $wnd.jQuery(e).closeModal({
+            complete: function () { obj.@gwt.material.design.client.ui.MaterialModal::onNativeClose(Z)(autoClosed); }
+        });
     }-*/;
 
     @Override
@@ -156,5 +196,10 @@ public class MaterialModal extends ComplexWidget implements HasType<ModalType>, 
     @Override
     public void setOpacity(double opacity) {
         this.opacity = opacity;
+    }
+
+    @Override
+    public HandlerRegistration addCloseHandler(CloseHandler<MaterialModal> handler) {
+        return this.addHandler(handler, CloseEvent.getType());
     }
 }


### PR DESCRIPTION
Now MaterialModal is implementing HasCloseHandlers, which makes its use far more natural for those who are familiar with GWT DialogBoxes. The `autoClosed` parameter is being set accordingly too.

To avoid issues when not using UiBinder, the MaterialModal also adds and removes itself from the document when opening/closing.

On MaterialAutoComplete, I changed the requirement to use MaterialSuggestionOracle to the more generic class SuggestOracle from GWT. In my tests, the issue #137 is already solved.

The code was formatted using the built-in Java conventions formatter from Eclipse, removing tabs for spaces, setting the max width to 110 columns, and setting the default indentation to 4 spaces.