### PR TITLE
Fix for issue #169.

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCutOut.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCutOut.java
@@ -359,21 +359,38 @@ public class MaterialCutOut extends ComplexWidget implements HasCloseHandlers<Ma
     }-*/;
     
     /**
-     * Gets the computed background color, based on the backgroundColor CSS class.
+     * Gets the computed background color, based on the backgroundColor CSS
+     * class.
      */
     private void setupComputedBackgroundColor() {
         // temp is just a widget created to evaluate the computed background
         // color
         ComplexWidget temp = new ComplexWidget(Document.get().createDivElement());
         temp.setBackgroundColor(backgroundColor);
+
+        // setting a style to make it invisible for the user
+        Style style = temp.getElement().getStyle();
+        style.setPosition(Position.FIXED);
+        style.setWidth(1, Unit.PX);
+        style.setHeight(1, Unit.PX);
+        style.setLeft(-10, Unit.PX);
+        style.setTop(-10, Unit.PX);
+        style.setZIndex(-10000);
+
+        // adding it to the body (on Chrome the component must be added to the
+        // DOM before getting computed values).
+        RootPanel.get().add(temp);
+
         String computed = getComputedBackgroundColor(temp.getElement()).toLowerCase();
+
+        // remove from the DOM after the evaluation
+        temp.removeFromParent();
 
         // convert rgb to rgba, considering the opacity field
         if (opacity < 1 && computed.startsWith("rgb(")) {
-            computed = computed.replace("rgb(", "rgba(").replace(")",
-                ", " + opacity + ")");
+            computed = computed.replace("rgb(", "rgba(").replace(")", ", " + opacity + ")");
         }
-        
+
         computedBackgroundColor = computed;
     }
     


### PR DESCRIPTION
Adding the temporary widget to the DOM by using `RootPanel.get().add()` instead of just `add()` to avoid problem when the parent itself is not added to the DOM yet (which can happen if not using UiBinder).

Also set a bunch of style properties to make sure the temporary widget won't show to the user as a glitch.