### PR TITLE
Created the HasTooltip interface and the TooltipMixin class.

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/base/ComplexWidget.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/ComplexWidget.java
@@ -20,34 +20,37 @@ package gwt.material.design.client.base;
  * #L%
  */
 
+import gwt.material.design.client.base.helper.StyleHelper;
+import gwt.material.design.client.base.mixin.ColorsMixin;
+import gwt.material.design.client.base.mixin.CssNameMixin;
+import gwt.material.design.client.base.mixin.EnabledMixin;
+import gwt.material.design.client.base.mixin.FocusableMixin;
+import gwt.material.design.client.base.mixin.FontSizeMixin;
+import gwt.material.design.client.base.mixin.GridMixin;
+import gwt.material.design.client.base.mixin.IdMixin;
+import gwt.material.design.client.base.mixin.ScrollspyMixin;
+import gwt.material.design.client.base.mixin.SeparatorMixin;
+import gwt.material.design.client.base.mixin.ShadowMixin;
+import gwt.material.design.client.base.mixin.ToggleStyleMixin;
+import gwt.material.design.client.base.mixin.TooltipMixin;
+import gwt.material.design.client.base.mixin.WavesMixin;
+import gwt.material.design.client.constants.CenterOn;
+import gwt.material.design.client.constants.HideOn;
+import gwt.material.design.client.constants.Position;
+import gwt.material.design.client.constants.ShowOn;
+import gwt.material.design.client.constants.TextAlign;
+import gwt.material.design.client.constants.WavesType;
+
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.Style;
 import com.google.gwt.user.client.ui.ComplexPanel;
 import com.google.gwt.user.client.ui.Focusable;
 import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.Widget;
-import gwt.material.design.client.base.helper.StyleHelper;
-import gwt.material.design.client.base.mixin.FontSizeMixin;
-import gwt.material.design.client.base.mixin.ToggleStyleMixin;
-import gwt.material.design.client.base.mixin.WavesMixin;
-import gwt.material.design.client.constants.TextAlign;
-import gwt.material.design.client.constants.CenterOn;
-import gwt.material.design.client.constants.HideOn;
-import gwt.material.design.client.constants.ShowOn;
-import gwt.material.design.client.base.mixin.ColorsMixin;
-import gwt.material.design.client.base.mixin.EnabledMixin;
-import gwt.material.design.client.base.mixin.FocusableMixin;
-import gwt.material.design.client.base.mixin.GridMixin;
-import gwt.material.design.client.base.mixin.IdMixin;
-import gwt.material.design.client.base.mixin.ScrollspyMixin;
-import gwt.material.design.client.base.mixin.SeparatorMixin;
-import gwt.material.design.client.base.mixin.ShadowMixin;
-import gwt.material.design.client.base.mixin.CssNameMixin;
-import gwt.material.design.client.constants.WavesType;
 
 public class ComplexWidget extends ComplexPanel implements HasId, HasEnabled, HasTextAlign, HasColors, HasGrid,
         HasShadow, Focusable, HasInlineStyle, HasSeparator, HasScrollspy, HasHideOn, HasShowOn, HasCenterOn,
-        HasCircle, HasWaves, HasDataAttributes, HasFloat {
+        HasCircle, HasWaves, HasDataAttributes, HasFloat, HasTooltip {
 
     private final IdMixin<ComplexWidget> idMixin = new IdMixin<>(this);
     private final EnabledMixin<ComplexWidget> enabledMixin = new EnabledMixin<>(this);
@@ -65,6 +68,7 @@ public class ComplexWidget extends ComplexPanel implements HasId, HasEnabled, Ha
     private final ToggleStyleMixin<ComplexWidget> circleMixin = new ToggleStyleMixin<>(this, "circle");
     private final WavesMixin<ComplexWidget> wavesMixin = new WavesMixin<>(this);
     private final CssNameMixin<ComplexWidget, Style.Float> floatMixin = new CssNameMixin<>(this);
+    private final TooltipMixin<ComplexWidget> tooltipMixin = new TooltipMixin<>(this);
 
     public ComplexWidget() {
     }
@@ -352,5 +356,35 @@ public class ComplexWidget extends ComplexPanel implements HasId, HasEnabled, Ha
     @Override
     public Style.Float getFloat() {
         return StyleHelper.fromStyleName(Style.Float.class, floatMixin.getCssName());
+    }
+
+    @Override
+    public String getTooltip() {
+        return tooltipMixin.getTooltip();
+    }
+
+    @Override
+    public void setTooltip(String tooltip) {
+        tooltipMixin.setTooltip(tooltip);
+    }
+
+    @Override
+    public Position getTooltipPosition() {
+        return tooltipMixin.getTooltipPosition();
+    }
+
+    @Override
+    public void setTooltipPosition(Position position) {
+        tooltipMixin.setTooltipPosition(position);
+    }
+
+    @Override
+    public int getTooltipDelayMs() {
+        return tooltipMixin.getTooltipDelayMs();
+    }
+
+    @Override
+    public void setTooltipDelayMs(int delayMs) {
+        tooltipMixin.setTooltipDelayMs(delayMs);
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/base/HasTooltip.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/HasTooltip.java
@@ -1,0 +1,70 @@
+package gwt.material.design.client.base;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2015 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import gwt.material.design.client.base.mixin.TooltipMixin;
+import gwt.material.design.client.constants.Position;
+import gwt.material.design.client.ui.MaterialTooltip;
+
+/**
+ * Interface that determines the class has a {@link MaterialTooltip} attached to
+ * it.
+ * 
+ * @author gilberto-torrezan
+ * 
+ * @see TooltipMixin
+ * @see ComplexWidget
+ */
+public interface HasTooltip {
+
+    /**
+     * @return the current tooltip text to be shown
+     */
+    String getTooltip();
+
+    /**
+     * Sets the tooltip text to be shown for the component.
+     */
+    void setTooltip(String tooltip);
+
+    /**
+     * @return the position where the tooltip text should appear, relative to
+     *         the component
+     */
+    Position getTooltipPosition();
+
+    /**
+     * Sets the {@link Position} where the tooltip text should appear, relative
+     * to the component.
+     */
+    void setTooltipPosition(Position position);
+
+    /**
+     * @return the delay in ms used to show the tooltip
+     */
+    int getTooltipDelayMs();
+
+    /**
+     * Sets the time in ms to show the tooltip text for the component
+     */
+    void setTooltipDelayMs(int delayMs);
+
+}

--- a/gwt-material/src/main/java/gwt/material/design/client/base/mixin/TooltipMixin.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/mixin/TooltipMixin.java
@@ -1,0 +1,85 @@
+package gwt.material.design.client.base.mixin;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2015 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import gwt.material.design.client.base.ComplexWidget;
+import gwt.material.design.client.base.HasTooltip;
+import gwt.material.design.client.constants.Position;
+import gwt.material.design.client.ui.MaterialTooltip;
+
+import com.google.gwt.user.client.ui.Widget;
+
+/**
+ * Mixin for the {@link MaterialTooltip} component.
+ * 
+ * @author gilberto-torrezan
+ * 
+ * @see HasTooltip
+ * @see ComplexWidget
+ */
+public class TooltipMixin<H extends Widget & HasTooltip> extends AbstractMixin<H> implements HasTooltip {
+
+    protected MaterialTooltip tooltip;
+
+    public TooltipMixin(H uiObject) {
+        super(uiObject);
+    }
+
+    protected void initializeTooltip() {
+        if (tooltip == null) {
+            tooltip = new MaterialTooltip(uiObject);
+        }
+    }
+
+    @Override
+    public String getTooltip() {
+        return tooltip == null ? null : tooltip.getText();
+    }
+
+    @Override
+    public void setTooltip(String tooltip) {
+        initializeTooltip();
+        this.tooltip.setText(tooltip);
+    }
+
+    @Override
+    public Position getTooltipPosition() {
+        return tooltip == null ? null : tooltip.getPosition();
+    }
+
+    @Override
+    public void setTooltipPosition(Position position) {
+        initializeTooltip();
+        this.tooltip.setPosition(position);
+    }
+
+    @Override
+    public int getTooltipDelayMs() {
+        return tooltip == null ? 0 : tooltip.getDelayMs();
+    }
+
+    @Override
+    public void setTooltipDelayMs(int delayMs) {
+        initializeTooltip();
+        this.tooltip.setDelayMs(delayMs);
+    }
+
+}


### PR DESCRIPTION
ComplexWidget modified to contain tooltips out of the box.

Note: the tooltip script is only initialized when a method from HasTooltip is invoked (to avoid overhead on widgets that don't have tooltip).

By using the mixin, all ComplexWidgets can now have a MaterialTooltip attach to them just by calling:

```java
widget.setTooltip("Hi, I'm a nice tooltip!");
```

or:

```xml
<m:MaterialLink text="Look at me" tooltip="Hi, I'm a nice tooltip!" />
```

Tooltip position and delay can also the set the same way.

I'd like to hear from you guys if we should override the `setTitle()` method from GWT UIObject to use MaterialTooltips instead.