### PR TITLE
Bugfix for #192 MaterialSwitch and MousePressedHandler

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollectionItem.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollectionItem.java
@@ -27,9 +27,11 @@ import com.google.gwt.event.dom.client.HasClickHandlers;
 import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.HasValue;
 import com.google.gwt.user.client.ui.Widget;
+
 import gwt.material.design.client.base.ComplexWidget;
 import gwt.material.design.client.base.HasAvatar;
 import gwt.material.design.client.base.HasDismissable;
+import gwt.material.design.client.base.helper.UiHelper;
 import gwt.material.design.client.base.mixin.ToggleStyleMixin;
 import gwt.material.design.client.constants.CollectionType;
 
@@ -52,6 +54,7 @@ public class MaterialCollectionItem extends ComplexWidget implements HasClickHan
     public MaterialCollectionItem() {
         super(Document.get().createLIElement());
         setStyleName("collection-item");
+        UiHelper.addMousePressedHandlers(this);
     }
 
     public void setType(CollectionType type) {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSwitch.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSwitch.java
@@ -74,6 +74,16 @@ public class MaterialSwitch extends ComplexWidget implements HasValue<Boolean>, 
         add(label);
         add(lblError);
         lblError.getElement().getStyle().setMarginTop(16, Unit.PX);
+        //register click handler here in order to have it at first position
+        // and therefore it will deal with clicks as first and setup the value
+        // right before others get notified.
+        addClickHandler(new ClickHandler() {
+            @Override
+            public void onClick(ClickEvent event) {
+                setValue(!getValue());
+                event.preventDefault();
+            }
+        });
     }
 
     /**
@@ -84,17 +94,10 @@ public class MaterialSwitch extends ComplexWidget implements HasValue<Boolean>, 
         setValue(value);
     }
 
+    
     @Override
     protected void onLoad() {
         super.onLoad();
-
-        addClickHandler(new ClickHandler() {
-            @Override
-            public void onClick(ClickEvent event) {
-                setValue(!getValue());
-                event.preventDefault();
-            }
-        });
     }
 
     @Override


### PR DESCRIPTION
- Bugfix for #192 as there was registered on each onLoad a new listener
- Bugfix for invalid value of MaterialSwitch when reading the value in the clickListener due to order of listener registration.
- Bugfix for visual Press Indication on MaterialCollectionItems on mobile devices