### PR TITLE
MaterialAutocomplete: fix suggestions limit

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialAutoComplete.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialAutoComplete.java
@@ -113,6 +113,7 @@ public class MaterialAutoComplete extends ComplexWidget implements HasError, Has
 
         item.setStyleName("multiValueSuggestBox-input-token");
         box = new SuggestBox(suggestions, itemBox);
+        setLimit(this.limit);
         String autocompleteId = DOM.createUniqueId();
         itemBox.getElement().setId(autocompleteId);
 
@@ -369,6 +370,9 @@ public class MaterialAutoComplete extends ComplexWidget implements HasError, Has
 
     public void setLimit(int limit) {
         this.limit = limit;
+        if (this.box != null) {
+            this.box.setLimit(limit);
+        }
     }
 
     @Override


### PR DESCRIPTION
A little fix to add the suggestions limit. Right now there is an issue in the suggestionbox that show limit+1 suggestions instead of limit 