### PR TITLE
MaterialLoader: fixed memory leak showing multiple time the loader

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialLoader.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialLoader.java
@@ -51,6 +51,15 @@ public class MaterialLoader {
     private static MaterialPreLoader preLoader = new MaterialPreLoader();
     private static MaterialProgress progress = new MaterialProgress();
 
+    static {
+        div.setStyleName("valign-wrapper loader-wrapper");
+        preLoader.getElement().getStyle().setProperty("margin", "auto");
+        preLoader.add(new MaterialSpinner("blue"));
+        preLoader.add(new MaterialSpinner("red"));
+        preLoader.add(new MaterialSpinner("yellow"));
+        preLoader.add(new MaterialSpinner("green"));
+    }
+
     /**
      * Show a circular loader.
      */
@@ -60,12 +69,6 @@ public class MaterialLoader {
 
     public static void showLoading(boolean isShow, Panel con) {
         if (isShow) {
-            div.setStyleName("valign-wrapper loader-wrapper");
-            preLoader.getElement().getStyle().setProperty("margin", "auto");
-            preLoader.add(new MaterialSpinner("blue"));
-            preLoader.add(new MaterialSpinner("red"));
-            preLoader.add(new MaterialSpinner("yellow"));
-            preLoader.add(new MaterialSpinner("green"));
             if(!(con instanceof RootPanel)) {
                 div.getElement().getStyle().setProperty("position", "absolute");
             }


### PR DESCRIPTION
Hi again :)
We've found a little ML. When the show is executed a lot of MaterialSpinner are added each time. I've moved the preloader initialization in a static block executed once.
