### PR TITLE
Fix enable/disable bugs

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/base/mixin/EnabledMixin.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/mixin/EnabledMixin.java
@@ -24,8 +24,7 @@ import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.user.client.ui.HasEnabled;
 import com.google.gwt.user.client.ui.UIObject;
 import com.google.gwt.user.client.ui.Widget;
-import gwt.material.design.client.base.HasWaves;
-import gwt.material.design.client.base.Waves;
+
 import gwt.material.design.client.base.helper.StyleHelper;
 
 /**
@@ -68,23 +67,9 @@ public class EnabledMixin<T extends UIObject & HasEnabled> extends AbstractMixin
         if(enabled) {
             obj.removeStyleName("disabled");
             obj.getElement().removeAttribute(DISABLED);
-
-            if(uiObject instanceof HasWaves) {
-                if(((HasWaves) uiObject).getWaves() == null) {
-                    uiObject.addStyleName(Waves.WAVES_STYLE);
-                    Waves.detectAndApply();
-                }
-            }
         } else {
             obj.addStyleName("disabled");
             obj.getElement().setAttribute(DISABLED, "");
-
-            if(uiObject instanceof HasWaves) {
-                if(((HasWaves) uiObject).getWaves() != null) {
-                    uiObject.removeStyleName(((HasWaves) uiObject).getWaves().getCssName());
-                }
-                uiObject.removeStyleName(Waves.WAVES_STYLE);
-            }
         }
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
@@ -431,6 +431,7 @@ public class MaterialDatePicker extends MaterialWidget implements HasGrid, HasEr
 
     @Override
     public void setEnabled(boolean enabled) {
-        dateInput.setEnabled(enabled);
+        super.setEnabled(enabled);
+        dateInput.setEnabled(enabled);    
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
@@ -537,6 +537,7 @@ public class MaterialValueBox<T> extends MaterialWidget implements HasChangeHand
 
     @Override
     public void setEnabled(boolean enabled) {
+        super.setEnabled(enabled);
         valueBoxBase.setEnabled(enabled);
     }
 }


### PR DESCRIPTION
The full calendar component gets enabled disabled now, not just the input box.
This also fixes isEnabled on MaterialValueBox which was not calling the super setEnabled method.
The waves was messing things up a bit. Removed! 
Does gwt-material really want to force wave style on enable/disable of components?

