### PR TITLE
Fixed: IndexOutOfBoundsException in MaterialCollapsibleBody

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsibleBody.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsibleBody.java
@@ -132,7 +132,8 @@ public class MaterialCollapsibleBody extends MaterialWidget implements HasCollap
         // Check if this widget has a valid href
         String href = child.getElement().getAttribute("href");
         String url = Window.Location.getHref();
-        String location = url.substring(url.indexOf("#"), url.length());
+        int pos = url.indexOf("#");
+        String location = pos >= 0 ? url.substring(pos, url.length()) : "";
 
         if(!href.isEmpty() && location.startsWith(href)) {
             ListItem li = findListItemParent(child);


### PR DESCRIPTION
Method checkActiveState of class MaterialCollapsibleBody expected to always find a "#" in the page url, otherwise threw a IndexOutOfBoundsException when calling url.substring, since the first parameter was -1.
