### PR TITLE
Added InitialClassMixin to be defined after attached event of MaterialWidget

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/base/AbstractButton.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/AbstractButton.java
@@ -73,6 +73,11 @@ public abstract class AbstractButton extends MaterialWidget implements HasHref, 
         getElement().getStyle().setCursor(Style.Cursor.POINTER);
     }
 
+    protected AbstractButton(String... initialClass) {
+        this();
+        setInitialClass(initialClass);
+    }
+
     protected AbstractButton(String text, String bgColor, WavesType waves) {
         this(null, text, bgColor);
         setWaves(waves);

--- a/gwt-material/src/main/java/gwt/material/design/client/base/AbstractIconButton.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/AbstractIconButton.java
@@ -61,6 +61,11 @@ public abstract class AbstractIconButton extends AbstractButton implements HasIc
         setIconPosition(IconPosition.LEFT);
     }
 
+    public AbstractIconButton(String... initialClass) {
+        super();
+        setInitialClass(initialClass);
+    }
+
     @Override
     public MaterialIcon getIcon() {
         return icon;

--- a/gwt-material/src/main/java/gwt/material/design/client/base/BaseCheckBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/BaseCheckBox.java
@@ -15,6 +15,27 @@
  */
 package gwt.material.design.client.base;
 
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
 import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.dom.client.InputElement;

--- a/gwt-material/src/main/java/gwt/material/design/client/base/HasInitialClass.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/HasInitialClass.java
@@ -1,10 +1,10 @@
-package gwt.material.design.client.ui;
+package gwt.material.design.client.base;
 
 /*
  * #%L
  * GwtMaterial
  * %%
- * Copyright (C) 2015 GwtMaterialDesign
+ * Copyright (C) 2015 - 2016 GwtMaterialDesign
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -20,21 +20,20 @@ package gwt.material.design.client.ui;
  * #L%
  */
 
-import gwt.material.design.client.base.MaterialWidget;
 
-import com.google.gwt.dom.client.Document;
 
-//@formatter:off
-/**
-* Card Element for action links. 
-* @author kevzlou7979
-* @author Ben Dol
-* @see <a href="http://gwt-material-demo.herokuapp.com/#cards">Material Cards</a>
-*/
-//@formatter:on
-public class MaterialCardAction extends MaterialWidget {
+public interface HasInitialClass {
 
-    public MaterialCardAction(){
-        super(Document.get().createDivElement(), "card-action");
-    }
+    /**
+     * Set the initial class into Material Components
+     * @param initialClass
+     */
+    void setInitialClass(String initialClass);
+
+    /**
+     * Get the initial class of Material Components
+     * @return
+     */
+    String getInitialClass();
+
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/base/HasInitialClass.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/HasInitialClass.java
@@ -28,12 +28,12 @@ public interface HasInitialClass {
      * Set the initial class into Material Components
      * @param initialClass
      */
-    void setInitialClass(String initialClass);
+    void setInitialClass(String... initialClass);
 
     /**
      * Get the initial class of Material Components
      * @return
      */
-    String getInitialClass();
+    String[] getInitialClass();
 
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/base/MaterialWidget.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/MaterialWidget.java
@@ -21,20 +21,7 @@ package gwt.material.design.client.base;
  */
 
 import gwt.material.design.client.base.helper.StyleHelper;
-import gwt.material.design.client.base.mixin.ColorsMixin;
-import gwt.material.design.client.base.mixin.CssNameMixin;
-import gwt.material.design.client.base.mixin.EnabledMixin;
-import gwt.material.design.client.base.mixin.FlexboxMixin;
-import gwt.material.design.client.base.mixin.FocusableMixin;
-import gwt.material.design.client.base.mixin.FontSizeMixin;
-import gwt.material.design.client.base.mixin.GridMixin;
-import gwt.material.design.client.base.mixin.IdMixin;
-import gwt.material.design.client.base.mixin.ScrollspyMixin;
-import gwt.material.design.client.base.mixin.SeparatorMixin;
-import gwt.material.design.client.base.mixin.ShadowMixin;
-import gwt.material.design.client.base.mixin.ToggleStyleMixin;
-import gwt.material.design.client.base.mixin.TooltipMixin;
-import gwt.material.design.client.base.mixin.WavesMixin;
+import gwt.material.design.client.base.mixin.*;
 import gwt.material.design.client.constants.CenterOn;
 import gwt.material.design.client.constants.Display;
 import gwt.material.design.client.constants.Flex;
@@ -57,8 +44,10 @@ import java.util.Iterator;
 
 public class MaterialWidget extends ComplexPanel implements HasId, HasEnabled, HasTextAlign, HasColors, HasGrid,
         HasShadow, Focusable, HasInlineStyle, HasSeparator, HasScrollspy, HasHideOn, HasShowOn, HasCenterOn,
-        HasCircle, HasWaves, HasDataAttributes, HasFloat, HasTooltip, HasFlexbox, HasHoverable, HasFontWeight, HasDepth {
+        HasCircle, HasWaves, HasDataAttributes, HasFloat, HasTooltip, HasFlexbox, HasHoverable, HasFontWeight, HasDepth, HasInitialClass {
 
+
+    private InitialClassMixin<MaterialWidget> initialClassMixin;
     private IdMixin<MaterialWidget> idMixin;
     private EnabledMixin<MaterialWidget> enabledMixin;
     private CssNameMixin<MaterialWidget, TextAlign> textAlignMixin;
@@ -84,8 +73,19 @@ public class MaterialWidget extends ComplexPanel implements HasId, HasEnabled, H
     public MaterialWidget() {
     }
 
+    public MaterialWidget(Element element, String initialClass) {
+        this(element);
+        setInitialClass(initialClass);
+    }
+
     public MaterialWidget(Element element) {
         setElement(element);
+    }
+
+    @Override
+    protected void onLoad() {
+        super.onLoad();
+
     }
 
     @Override
@@ -206,6 +206,11 @@ public class MaterialWidget extends ComplexPanel implements HasId, HasEnabled, H
     public ToggleStyleMixin<MaterialWidget> getTruncateMixin() {
         if(truncateMixin == null) { truncateMixin = new ToggleStyleMixin<>(this, "truncate"); }
         return truncateMixin;
+    }
+
+    public InitialClassMixin<MaterialWidget> getInitialClassMixin() {
+        if(initialClassMixin == null) { initialClassMixin = new InitialClassMixin<>(this); }
+        return initialClassMixin;
     }
 
     @Override
@@ -692,4 +697,14 @@ public class MaterialWidget extends ComplexPanel implements HasId, HasEnabled, H
             event.stopPropagation();
         });
     }-*/;
+
+    @Override
+    public void setInitialClass(String initialClass) {
+        getInitialClassMixin().setInitialClass(initialClass);
+    }
+
+    @Override
+    public String getInitialClass() {
+        return getInitialClassMixin().getInitialClass();
+    }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/base/MaterialWidget.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/MaterialWidget.java
@@ -73,7 +73,7 @@ public class MaterialWidget extends ComplexPanel implements HasId, HasEnabled, H
     public MaterialWidget() {
     }
 
-    public MaterialWidget(Element element, String initialClass) {
+    public MaterialWidget(Element element, String... initialClass) {
         this(element);
         setInitialClass(initialClass);
     }
@@ -699,12 +699,12 @@ public class MaterialWidget extends ComplexPanel implements HasId, HasEnabled, H
     }-*/;
 
     @Override
-    public void setInitialClass(String initialClass) {
+    public void setInitialClass(String... initialClass) {
         getInitialClassMixin().setInitialClass(initialClass);
     }
 
     @Override
-    public String getInitialClass() {
+    public String[] getInitialClass() {
         return getInitialClassMixin().getInitialClass();
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/base/MaterialWidget.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/MaterialWidget.java
@@ -83,12 +83,6 @@ public class MaterialWidget extends ComplexPanel implements HasId, HasEnabled, H
     }
 
     @Override
-    protected void onLoad() {
-        super.onLoad();
-
-    }
-
-    @Override
     public void add(final Widget child) {
         add(child, (Element) getElement());
     }

--- a/gwt-material/src/main/java/gwt/material/design/client/base/mixin/InitialClassMixin.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/mixin/InitialClassMixin.java
@@ -1,0 +1,64 @@
+package gwt.material.design.client.base.mixin;
+
+/*
+ * #%L
+ * GwtMaterial
+ * %%
+ * Copyright (C) 2015 - 2016 GwtMaterialDesign
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+
+import com.google.gwt.event.logical.shared.AttachEvent;
+import com.google.gwt.user.client.ui.UIObject;
+import com.google.gwt.user.client.ui.Widget;
+import gwt.material.design.client.base.HasInitialClass;
+
+/**
+ * @author kevzlou7979
+ */
+public class InitialClassMixin<T extends UIObject & HasInitialClass> extends AbstractMixin<T> implements HasInitialClass {
+
+    private String initialClass;
+
+    public InitialClassMixin(final T uiObject) {
+        super(uiObject);
+    }
+
+
+    @Override
+    public void setInitialClass(final String initialClass) {
+        this.initialClass = initialClass;
+        ((Widget)uiObject).addAttachHandler(new AttachEvent.Handler() {
+            @Override
+            public void onAttachOrDetach(AttachEvent event) {
+                if(initialClass != null && !initialClass.isEmpty()) {
+                    uiObject.removeStyleName(initialClass);
+                }
+                if(event.isAttached()){
+                    if(initialClass != null && !initialClass.isEmpty()) {
+                        uiObject.addStyleName(initialClass);
+                    }
+                }
+            }
+        });
+    }
+
+
+    @Override
+    public String getInitialClass() {
+        return initialClass;
+    }
+}

--- a/gwt-material/src/main/java/gwt/material/design/client/base/mixin/InitialClassMixin.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/mixin/InitialClassMixin.java
@@ -31,7 +31,7 @@ import gwt.material.design.client.base.HasInitialClass;
  */
 public class InitialClassMixin<T extends UIObject & HasInitialClass> extends AbstractMixin<T> implements HasInitialClass {
 
-    private String initialClass;
+    private String[] initialClass;
 
     public InitialClassMixin(final T uiObject) {
         super(uiObject);
@@ -39,17 +39,20 @@ public class InitialClassMixin<T extends UIObject & HasInitialClass> extends Abs
 
 
     @Override
-    public void setInitialClass(final String initialClass) {
+    public void setInitialClass(final String... initialClass) {
         this.initialClass = initialClass;
         ((Widget)uiObject).addAttachHandler(new AttachEvent.Handler() {
             @Override
             public void onAttachOrDetach(AttachEvent event) {
-                if(initialClass != null && !initialClass.isEmpty()) {
-                    uiObject.removeStyleName(initialClass);
-                }
-                if(event.isAttached()){
-                    if(initialClass != null && !initialClass.isEmpty()) {
-                        uiObject.addStyleName(initialClass);
+
+                for(String s : initialClass) {
+                    if(initialClass != null && !s.isEmpty()) {
+                        uiObject.removeStyleName(s);
+                    }
+                    if(event.isAttached()){
+                        if(initialClass != null && !s.isEmpty()) {
+                            uiObject.addStyleName(s);
+                        }
                     }
                 }
             }
@@ -58,7 +61,7 @@ public class InitialClassMixin<T extends UIObject & HasInitialClass> extends Abs
 
 
     @Override
-    public String getInitialClass() {
+    public String[] getInitialClass() {
         return initialClass;
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/base/mixin/InitialClassMixin.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/mixin/InitialClassMixin.java
@@ -41,22 +41,24 @@ public class InitialClassMixin<T extends UIObject & HasInitialClass> extends Abs
     @Override
     public void setInitialClass(final String... initialClass) {
         this.initialClass = initialClass;
-        ((Widget)uiObject).addAttachHandler(new AttachEvent.Handler() {
-            @Override
-            public void onAttachOrDetach(AttachEvent event) {
+        if(!((Widget)uiObject).isAttached()){
+            ((Widget)uiObject).addAttachHandler(new AttachEvent.Handler() {
+                @Override
+                public void onAttachOrDetach(AttachEvent event) {
 
-                for(String s : initialClass) {
-                    if(initialClass != null && !s.isEmpty()) {
-                        uiObject.removeStyleName(s);
-                    }
-                    if(event.isAttached()){
+                    for(String s : initialClass) {
                         if(initialClass != null && !s.isEmpty()) {
-                            uiObject.addStyleName(s);
+                            uiObject.removeStyleName(s);
+                        }
+                        if(event.isAttached()){
+                            if(initialClass != null && !s.isEmpty()) {
+                                uiObject.addStyleName(s);
+                            }
                         }
                     }
                 }
-            }
-        });
+            });
+        }
     }
 
 

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialBadge.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialBadge.java
@@ -20,6 +20,7 @@ package gwt.material.design.client.ui;
  * #L%
  */
 
+import com.google.gwt.dom.client.Document;
 import gwt.material.design.client.ui.html.Span;
 
 import com.google.gwt.user.client.ui.HasText;
@@ -45,7 +46,7 @@ public class MaterialBadge extends Span implements HasText {
      * Collection, DropDown, SideNav and any other Material components.
      */
     public MaterialBadge() {
-        setInitialClass("badge sideBarBadge");
+        super(Document.get().createSpanElement(), "badge", "sideBarBadge");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialBadge.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialBadge.java
@@ -45,7 +45,7 @@ public class MaterialBadge extends Span implements HasText {
      * Collection, DropDown, SideNav and any other Material components.
      */
     public MaterialBadge() {
-        setStyleName("badge sideBarBadge");
+        setInitialClass("badge sideBarBadge");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialBreadcrumb.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialBreadcrumb.java
@@ -49,7 +49,7 @@ import gwt.material.design.client.base.AbstractIconButton;
 public class MaterialBreadcrumb extends AbstractIconButton {
 
     public MaterialBreadcrumb() {
-        setInitialClass("breadcrumb");
+        super("breadcrumb");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialBreadcrumb.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialBreadcrumb.java
@@ -49,7 +49,7 @@ import gwt.material.design.client.base.AbstractIconButton;
 public class MaterialBreadcrumb extends AbstractIconButton {
 
     public MaterialBreadcrumb() {
-        setStyleName("breadcrumb");
+        setInitialClass("breadcrumb");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCard.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCard.java
@@ -101,8 +101,7 @@ public class MaterialCard extends MaterialWidget implements HasAxis {
      * Creates and empty card.
      */
     public MaterialCard() {
-        super(Document.get().createDivElement());
-        setStyleName("card");
+        super(Document.get().createDivElement(), "card");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardContent.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardContent.java
@@ -35,7 +35,6 @@ import com.google.gwt.dom.client.Document;
 public class MaterialCardContent extends MaterialWidget {
 
     public MaterialCardContent() {
-        super(Document.get().createDivElement());
-        setStyleName("card-content");
+        super(Document.get().createDivElement(), "card-content");
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardImage.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardImage.java
@@ -37,8 +37,7 @@ import com.google.gwt.user.client.ui.Widget;
 public class MaterialCardImage extends MaterialWidget {
 
     public MaterialCardImage(){
-        super(Document.get().createDivElement());
-        setStyleName("card-image");
+        super(Document.get().createDivElement(), "card-image");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardReveal.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardReveal.java
@@ -35,7 +35,6 @@ import com.google.gwt.dom.client.Document;
 public class MaterialCardReveal extends MaterialWidget {
 
     public MaterialCardReveal(){
-        super(Document.get().createDivElement());
-        setStyleName("card-reveal");
+        super(Document.get().createDivElement(), "card-reveal");
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardTitle.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardTitle.java
@@ -45,8 +45,7 @@ public class MaterialCardTitle extends MaterialWidget implements HasIcon, HasTex
     private Span span = new Span();
 
     public MaterialCardTitle() {
-        super(Document.get().createSpanElement());
-        setStyleName("card-title activator");
+        super(Document.get().createSpanElement(), "card-title activator");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardTitle.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCardTitle.java
@@ -45,7 +45,7 @@ public class MaterialCardTitle extends MaterialWidget implements HasIcon, HasTex
     private Span span = new Span();
 
     public MaterialCardTitle() {
-        super(Document.get().createSpanElement(), "card-title activator");
+        super(Document.get().createSpanElement(), "card-title" , "activator");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialChip.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialChip.java
@@ -72,8 +72,7 @@ public class MaterialChip extends MaterialWidget implements HasImage, HasIcon, H
      * Creates an empty chip.
      */
     public MaterialChip() {
-        super(Document.get().createDivElement());
-        setStyleName("chip");
+        super(Document.get().createDivElement(), "chip");
     }
 
     public void setText(String text){

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsible.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsible.java
@@ -100,8 +100,7 @@ public class MaterialCollapsible extends MaterialWidget implements HasSelectable
      * Creates an empty collapsible
      */
     public MaterialCollapsible() {
-        super(Document.get().createULElement());
-        setStyleName("collapsible");
+        super(Document.get().createULElement(), "collapsible");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsibleBody.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsibleBody.java
@@ -49,8 +49,7 @@ public class MaterialCollapsibleBody extends MaterialWidget implements HasCollap
      * Creates empty collapsible body.
      */
     public MaterialCollapsibleBody() {
-        super(Document.get().createDivElement());
-        setStyleName("collapsible-body");
+        super(Document.get().createDivElement(), "collapsible-body");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsibleHeader.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsibleHeader.java
@@ -43,8 +43,7 @@ public class MaterialCollapsibleHeader extends MaterialWidget implements HasAllM
     /** Creates empty collapsible header.
      */
     public MaterialCollapsibleHeader() {
-        super(Document.get().createDivElement());
-        setStyleName("collapsible-header");
+        super(Document.get().createDivElement(), "collapsible-header");
     }
 
     /** Adds other components as header.

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollection.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollection.java
@@ -97,8 +97,7 @@ public class MaterialCollection extends MaterialWidget {
      * Creates an empty collection component.
      */
     public MaterialCollection() {
-        super(Document.get().createULElement());
-        setStyleName("collection");
+        super(Document.get().createULElement(), "collection");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollectionItem.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollectionItem.java
@@ -52,8 +52,7 @@ public class MaterialCollectionItem extends MaterialWidget implements HasClickHa
     private HandlerRegistration handlerReg;
 
     public MaterialCollectionItem() {
-        super(Document.get().createLIElement());
-        setStyleName("collection-item");
+        super(Document.get().createLIElement(), "collection-item");
         UiHelper.addMousePressedHandlers(this);
     }
 

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollectionSecondary.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollectionSecondary.java
@@ -35,8 +35,7 @@ import gwt.material.design.client.base.HasHref;
 public class MaterialCollectionSecondary extends MaterialWidget implements HasHref {
 
     public MaterialCollectionSecondary() {
-        super(Document.get().createAnchorElement());
-        setStyleName("secondary-content");
+        super(Document.get().createAnchorElement(), "secondary-content");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialColumn.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialColumn.java
@@ -52,8 +52,7 @@ public class MaterialColumn extends MaterialWidget implements HasWaves, HasVisib
         HasAllMouseHandlers, HasDoubleClickHandlers {
 
     public MaterialColumn() {
-        super(Document.get().createDivElement());
-        setStyleName("col");
+        super(Document.get().createDivElement(), "col");
     }
 
     public MaterialColumn(int small, int medium, int large) {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
@@ -87,8 +87,7 @@ public class MaterialDatePicker extends MaterialWidget implements HasGrid, HasEr
     private boolean initialized = false;
 
     public MaterialDatePicker() {
-        super(Document.get().createDivElement());
-        addStyleName("input-field");
+        super(Document.get().createDivElement(), "input-field");
 
         dateInput = new DateInput();
         add(dateInput);

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDivider.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDivider.java
@@ -42,7 +42,6 @@ import gwt.material.design.client.base.MaterialWidget;
 public class MaterialDivider extends MaterialWidget {
 
     public MaterialDivider() {
-        super(Document.get().createElement("div"));
-        setStyleName("divider");
+        super(Document.get().createElement("div"), "divider");
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDropDown.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDropDown.java
@@ -78,7 +78,7 @@ public class MaterialDropDown extends UnorderedList implements HasSelectionHandl
     private List<Widget> children = new ArrayList<>();
 
     public MaterialDropDown() {
-        setStyleName("dropdown-content");
+        setInitialClass("dropdown-content");
         setId(DOM.createUniqueId());
     }
 

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialFAB.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialFAB.java
@@ -67,8 +67,7 @@ public class MaterialFAB extends MaterialWidget implements HasType<FABType>, Has
     private boolean toggle = true;
 
     public MaterialFAB() {
-        super(Document.get().createDivElement());
-        setStyleName("fixed-action-btn");
+        super(Document.get().createDivElement(), "fixed-action-btn");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialFooter.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialFooter.java
@@ -68,8 +68,7 @@ public class MaterialFooter extends MaterialWidget implements HasType<FooterType
     private final CssTypeMixin<FooterType, MaterialFooter> typeMixin = new CssTypeMixin<>(this);
 
     public MaterialFooter() {
-        super(Document.get().createElement("footer"));
-        setStyleName("page-footer");
+        super(Document.get().createElement("footer"), "page-footer");
         container.setStyleName("container");
         super.add(container);
     }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialFooterCopyright.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialFooterCopyright.java
@@ -38,8 +38,7 @@ public class MaterialFooterCopyright extends MaterialWidget {
     private Div container = new Div();
 
     public MaterialFooterCopyright() {
-        super(Document.get().createDivElement());
-        setStyleName("footer-copyright");
+        super(Document.get().createDivElement(), "footer-copyright");
         container.setStyleName("container");
         super.add(container);
     }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialIcon.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialIcon.java
@@ -64,7 +64,7 @@ public class MaterialIcon extends AbstractButton implements HasSeparator, HasIco
      */
     public MaterialIcon() {
         super();
-        addStyleName("material-icons");
+        setInitialClass("material-icons");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialIcon.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialIcon.java
@@ -63,8 +63,7 @@ public class MaterialIcon extends AbstractButton implements HasSeparator, HasIco
      * Creates an empty icon.
      */
     public MaterialIcon() {
-        super();
-        setInitialClass("material-icons");
+        super("material-icons");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialImage.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialImage.java
@@ -66,7 +66,7 @@ public class MaterialImage extends MaterialWidget implements HasCaption, HasType
      * Creates an empty image.
      */
     public MaterialImage() {
-        super(Document.get().createImageElement());
+        super(Document.get().createImageElement(), "responsive-img");
     }
 
     /**
@@ -104,8 +104,6 @@ public class MaterialImage extends MaterialWidget implements HasCaption, HasType
     @Override
     public void onLoad() {
         super.onLoad();
-
-        addStyleName("responsive-img");
         onInitMaterialDesign();
     }
 

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialInput.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialInput.java
@@ -30,7 +30,7 @@ import gwt.material.design.client.constants.InputType;
 import gwt.material.design.client.base.HasInputType;
 import gwt.material.design.client.base.ValueBoxBase;
 
-public class MaterialInput extends ValueBoxBase<String> implements HasInputType {
+public class  MaterialInput extends ValueBoxBase<String> implements HasInputType {
 
     private static final String MIN = "min";
     private static final String MAX = "max";

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialLabel.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialLabel.java
@@ -52,8 +52,7 @@ public class MaterialLabel extends MaterialWidget implements HasGrid, HasSeparat
     private final FontSizeMixin<MaterialLabel> fontSizeMixin = new FontSizeMixin<>(this);
 
     public MaterialLabel() {
-        super(Document.get().createSpanElement());
-        setStyleName("material-label");
+        super(Document.get().createSpanElement(), "material-label");
     }
 
     public MaterialLabel(String text) {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListBox.java
@@ -82,8 +82,7 @@ public class MaterialListBox extends MaterialWidget implements HasId, HasGrid, H
 
 
     public MaterialListBox() {
-        super(Document.get().createDivElement());
-        addStyleName("input-field");
+        super(Document.get().createDivElement(), "input-field");
         add(listBox);
         add(lblName);
         toggleOldMixin = new ToggleStyleMixin<>(listBox, "browser-default");

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
@@ -88,8 +88,7 @@ public class MaterialModal extends MaterialWidget implements HasType<ModalType>,
     private double opacity = 0.5;
 
     public MaterialModal() {
-        super(Document.get().createDivElement());
-        setStyleName("modal");
+        super(Document.get().createDivElement(), "modal");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModalContent.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModalContent.java
@@ -30,7 +30,7 @@ package gwt.material.design.client.ui;
 public class MaterialModalContent extends MaterialPanel {
 
     public MaterialModalContent() {
-        setInitialClass("modal-content");
+        super("modal-content");
     }
 
     public void setHeight(String height) {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModalContent.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModalContent.java
@@ -30,7 +30,7 @@ package gwt.material.design.client.ui;
 public class MaterialModalContent extends MaterialPanel {
 
     public MaterialModalContent() {
-        setStyleName("modal-content");
+        setInitialClass("modal-content");
     }
 
     public void setHeight(String height) {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModalFooter.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModalFooter.java
@@ -30,6 +30,6 @@ package gwt.material.design.client.ui;
 public class MaterialModalFooter extends MaterialPanel {
 
     public MaterialModalFooter() {
-        setStyleName("modal-footer");
+        setInitialClass("modal-footer");
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModalFooter.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModalFooter.java
@@ -30,6 +30,6 @@ package gwt.material.design.client.ui;
 public class MaterialModalFooter extends MaterialPanel {
 
     public MaterialModalFooter() {
-        setInitialClass("modal-footer");
+        super("modal-footer");
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialNavBrand.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialNavBrand.java
@@ -60,8 +60,7 @@ public class MaterialNavBrand extends MaterialWidget implements HasText, HasHref
      */
     @UiConstructor
     public MaterialNavBrand() {
-        super(Document.get().createElement("a"));
-        this.addStyleName("brand-logo");
+        super(Document.get().createElement("a"), "brand-logo");
 
     }
 

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialNoResult.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialNoResult.java
@@ -58,8 +58,7 @@ public class MaterialNoResult extends MaterialWidget implements HasIcon, HasTitl
     private Div div = new Div();
 
     public MaterialNoResult() {
-        super(Document.get().createDivElement());
-        setStyleName("valign-wrapper");
+        super(Document.get().createDivElement(), "valign-wrapper");
         setTextAlign(TextAlign.CENTER);
         setHeight("100%");
         add(div);

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialPager.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialPager.java
@@ -66,8 +66,7 @@ public class MaterialPager extends MaterialWidget {
     private MaterialChip indicator;
 
     public MaterialPager() {
-        super(Document.get().createULElement());
-        addStyleName("pagination");
+        super(Document.get().createULElement(), "pagination");
         setWaves(WavesType.DEFAULT);
         removeStyleName("waves-effect");
     }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialPanel.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialPanel.java
@@ -37,6 +37,10 @@ import com.google.gwt.dom.client.Document;
  */
 public class MaterialPanel extends MaterialWidget {
 
+    public MaterialPanel(String... initialClass) {
+        super(Document.get().createDivElement(), initialClass);
+    }
+
     public MaterialPanel() {
         super(Document.get().createDivElement());
     }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialParallax.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialParallax.java
@@ -63,8 +63,7 @@ public class MaterialParallax extends MaterialWidget {
     private Div div = new Div();
 
     public MaterialParallax() {
-        setElement(Document.get().createDivElement());
-        setStyleName("parallax-container");
+        super(Document.get().createDivElement(), "parallax-container");
         super.add(div);
         div.setStyleName("parallax");
     }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialPreLoader.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialPreLoader.java
@@ -49,7 +49,7 @@ public class MaterialPreLoader extends MaterialWidget {
 
 
     public MaterialPreLoader() {
-        super(Document.get().createDivElement(), "preloader-wrapper active");
+        super(Document.get().createDivElement(), "preloader-wrapper", "active");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialPreLoader.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialPreLoader.java
@@ -49,8 +49,7 @@ public class MaterialPreLoader extends MaterialWidget {
 
 
     public MaterialPreLoader() {
-        super(Document.get().createDivElement());
-        setStyleName("preloader-wrapper active");
+        super(Document.get().createDivElement(), "preloader-wrapper active");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialProgress.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialProgress.java
@@ -46,7 +46,7 @@ public class MaterialProgress extends Div implements HasType<ProgressType> {
 
     public MaterialProgress() {
         super();
-        setStyleName("progress");
+        setInitialClass("progress");
         getElement().getStyle().setMargin(0, Unit.PX);
         add(div);
         setType(ProgressType.INDETERMINATE);

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialProgress.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialProgress.java
@@ -45,8 +45,7 @@ public class MaterialProgress extends Div implements HasType<ProgressType> {
     private double percent = 0;
 
     public MaterialProgress() {
-        super();
-        setInitialClass("progress");
+        super("progress");
         getElement().getStyle().setMargin(0, Unit.PX);
         add(div);
         setType(ProgressType.INDETERMINATE);

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialRow.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialRow.java
@@ -48,7 +48,6 @@ import com.google.gwt.dom.client.Document;
 public class MaterialRow extends MaterialWidget {
 
     public MaterialRow(){
-        super(Document.get().createDivElement());
-        setStyleName("row");
+        super(Document.get().createDivElement(), "row");
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialScrollspy.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialScrollspy.java
@@ -68,7 +68,7 @@ import gwt.material.design.client.ui.html.UnorderedList;
 public class MaterialScrollspy extends UnorderedList {
 
     public MaterialScrollspy() {
-        setStyleName("section table-of-contents");
+        setInitialClass("section table-of-contents");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialScrollspy.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialScrollspy.java
@@ -68,7 +68,7 @@ import gwt.material.design.client.ui.html.UnorderedList;
 public class MaterialScrollspy extends UnorderedList {
 
     public MaterialScrollspy() {
-        setInitialClass("section table-of-contents");
+        super("section", "table-of-contents");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSearchResult.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSearchResult.java
@@ -36,8 +36,7 @@ import gwt.material.design.client.base.MaterialWidget;
 public class MaterialSearchResult extends MaterialWidget {
 
     public MaterialSearchResult() {
-        super(Document.get().createDivElement());
-        setStyleName("search-result");
+        super(Document.get().createDivElement(), "search-result");
     }
 
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSection.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSection.java
@@ -44,7 +44,6 @@ import com.google.gwt.dom.client.Document;
 public class MaterialSection extends MaterialWidget {
 
     public MaterialSection() {
-        super(Document.get().createElement("div"));
-        setStyleName("section");
+        super(Document.get().createElement("div"), "section");
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSideNav.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSideNav.java
@@ -85,8 +85,7 @@ public class MaterialSideNav extends MaterialWidget implements HasType<SideNavTy
      * Icons or any other material components.
      */
     public MaterialSideNav() {
-        super(Document.get().createULElement());
-        setStyleName("side-nav");
+        super(Document.get().createULElement(), "side-nav");
     }
 
     /**

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSlideCaption.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSlideCaption.java
@@ -36,7 +36,6 @@ import com.google.gwt.dom.client.Document;
 public class MaterialSlideCaption extends MaterialWidget {
 
     public MaterialSlideCaption() {
-        super(Document.get().createDivElement());
-        setStyleName("caption");
+        super(Document.get().createDivElement(), "caption");
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSlider.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSlider.java
@@ -70,8 +70,7 @@ public class MaterialSlider extends MaterialWidget {
     private final ToggleStyleMixin<MaterialSlider> fsMixin = new ToggleStyleMixin<>(this, "fullscreen");
 
     public MaterialSlider() {
-        super(Document.get().createDivElement());
-        setStyleName("slider");
+        super(Document.get().createDivElement(), "slider");
         ul.setStyleName("slides");
         super.add(ul);
     }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSpinner.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSpinner.java
@@ -51,8 +51,7 @@ public class MaterialSpinner extends MaterialWidget {
     private Div gapPatch = new Div();
 
     public MaterialSpinner() {
-        super(Document.get().createDivElement());
-        setStyleName("spinner-layer");
+        super(Document.get().createDivElement(), "spinner-layer");
         add(circleClipperLeft);
         circleClipperLeft.add(circle1);
         add(gapPatch);

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSplashScreen.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSplashScreen.java
@@ -69,8 +69,7 @@ public class MaterialSplashScreen extends MaterialWidget implements HasVisibilit
     private MaterialProgress progress = new MaterialProgress();
 
     public MaterialSplashScreen(){
-        super(Document.get().createDivElement());
-        setStyleName("splash-screen");
+        super(Document.get().createDivElement(), "splash-screen");
         setDisplay(Display.NONE);
         div.setWidth("100%");
         div.getElement().getStyle().setMarginTop(15, Style.Unit.PCT);

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSwitch.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSwitch.java
@@ -65,8 +65,7 @@ public class MaterialSwitch extends MaterialWidget implements HasValue<Boolean>,
      * Creates a switch element
      */
     public MaterialSwitch() {
-        super(Document.get().createDivElement());
-        setStyleName("switch");
+        super(Document.get().createDivElement(), "switch");
         span.setStyleName("lever");
         input.setType(InputType.CHECKBOX);
         label.add(input);

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTab.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTab.java
@@ -21,6 +21,7 @@ package gwt.material.design.client.ui;
  */
 
 import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.logical.shared.AttachEvent;
 import com.google.gwt.user.client.ui.Widget;
 import gwt.material.design.client.base.HasType;
 import gwt.material.design.client.base.MaterialWidget;
@@ -70,19 +71,25 @@ public class MaterialTab extends UnorderedList implements HasType<TabType> {
 
     public MaterialTab() {
         super();
-        setStyleName("tabs");
+        setInitialClass("tabs");
     }
 
     @Override
     public void onLoad() {
         super.onLoad();
+        this.addAttachHandler(new AttachEvent.Handler() {
+            @Override
+            public void onAttachOrDetach(AttachEvent event) {
+                if(event.isAttached()) {
+                    initialize();
 
-        initialize();
+                    indicator = new MaterialWidget(getIndicatorElement(getElement()));
+                    indicatorColorMixin = new ColorsMixin<>(indicator);
 
-        indicator = new MaterialWidget(getIndicatorElement(getElement()));
-        indicatorColorMixin = new ColorsMixin<>(indicator);
-
-        setIndicatorColor(indicatorColor);
+                    setIndicatorColor(indicatorColor);
+                }
+            }
+        });
     }
 
     public int getTabIndex() {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTab.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTab.java
@@ -70,8 +70,7 @@ public class MaterialTab extends UnorderedList implements HasType<TabType> {
     private final CssTypeMixin<TabType, MaterialTab> typeMixin = new CssTypeMixin<>(this);
 
     public MaterialTab() {
-        super();
-        setInitialClass("tabs");
+        super("tabs");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTabItem.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTabItem.java
@@ -42,8 +42,7 @@ public class MaterialTabItem extends ListItem {
     private MaterialTab parent;
 
     public MaterialTabItem() {
-        super();
-        setStyleName("tab");
+        super("tab");
     }
 
     @Override

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
@@ -108,8 +108,7 @@ public class MaterialValueBox<T> extends MaterialWidget implements HasChangeHand
     private final ErrorMixin<MaterialValueBox<T>, MaterialLabel> errorMixin = new ErrorMixin<>(this, lblError, valueBoxBase);
 
     public MaterialValueBox() {
-        super(Document.get().createDivElement());
-        setStyleName("input-field");
+        super(Document.get().createDivElement(), "input-field");
     }
     
     public MaterialValueBox(ValueBoxBase<T> tValueBox) {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialVideo.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialVideo.java
@@ -48,7 +48,7 @@ public class MaterialVideo extends MaterialWidget implements HasGrid{
     private Frame frame =  new Frame();
 
     public MaterialVideo() {
-        super(Document.get().createElement("div"));
+        super(Document.get().createElement("div"), "video-container");
         add(frame);
     }
 
@@ -58,7 +58,6 @@ public class MaterialVideo extends MaterialWidget implements HasGrid{
 
     public void setUrl(String url) {
         frame.setUrl(url);
-        this.addStyleName("video-container");
         this.add(frame);
     }
 

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/html/Div.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/html/Div.java
@@ -33,6 +33,10 @@ public class Div extends MaterialWidget implements HasClickHandlers {
         super(Document.get().createElement("div"));
     }
 
+    public Div(String... initialClass) {
+        super(Document.get().createDivElement(), initialClass);
+    }
+
     @Override
     public HandlerRegistration addClickHandler(ClickHandler handler) {
         return addDomHandler(handler, ClickEvent.getType());

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/html/ListItem.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/html/ListItem.java
@@ -20,6 +20,7 @@ package gwt.material.design.client.ui.html;
  * #L%
  */
 
+import com.google.gwt.dom.client.Document;
 import com.google.gwt.dom.client.Element;
 import com.google.gwt.user.client.DOM;
 import com.google.gwt.user.client.ui.Widget;
@@ -28,7 +29,11 @@ import gwt.material.design.client.base.MaterialWidget;
 public class ListItem extends MaterialWidget {
 
     public ListItem() {
-        setElement((Element)DOM.createElement("li"));
+        super(Document.get().createLIElement());
+    }
+
+    public ListItem(String... initialClass) {
+        super(Document.get().createLIElement(), initialClass);
     }
 
     public ListItem(Widget item) {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/html/Span.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/html/Span.java
@@ -21,6 +21,7 @@ package gwt.material.design.client.ui.html;
  */
 
 import com.google.gwt.dom.client.Document;
+import com.google.gwt.dom.client.Element;
 import com.google.gwt.event.dom.client.ClickEvent;
 import com.google.gwt.event.dom.client.ClickHandler;
 import com.google.gwt.event.dom.client.HasClickHandlers;
@@ -33,6 +34,10 @@ public class Span extends MaterialWidget implements HasClickHandlers, HasText {
 
     public Span() {
         super(Document.get().createElement("span"));
+    }
+
+    public Span(Element e, String... initialClass) {
+        super(e, initialClass);
     }
 
     public Span(String string) {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/html/UnorderedList.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/html/UnorderedList.java
@@ -32,6 +32,10 @@ public class UnorderedList extends MaterialWidget {
         super(Document.get().createULElement());
     }
 
+    public UnorderedList(String... initialClass) {
+        super(Document.get().createULElement(), initialClass);
+    }
+
     @Override
     public void add(Widget child) {
         if(child instanceof ListItem) {


### PR DESCRIPTION
Created InitialClassMixin to setInitialClass(String initialClass) and on MaterialWidget - Added a super contructor with params Element and String initialClass to be inject on attached event of each widget.

This will also fixed the problem on GMD integration with Errai https://github.com/errai/errai/issues/170 - Preventing the errai ui to override the style classnames on Widget Injection.

Tested on Demo, Pattern and Starter showcase about the changes. :+1: 
Tested on gwt-material-errai :+1: 

Will update also the addins to have the same feature.