### PR TITLE
issue #317

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 
 ## Demo
 * [1.5.0 Release Demo](http://gwtmaterialdesign.github.io/gwt-material-demo/)
+* [1.5.1 Snapshot Demo](http://gwtmaterialdesign.github.io/gwt-material-demo/snapshot/)
 
 ## Documentation
 Support documentation can be found [here](https://github.com/GwtMaterialDesign/gwt-material/wiki) <br/>
@@ -54,9 +55,9 @@ Please follow the [contribution document](https://github.com/GwtMaterialDesign/g
 
 ## R</li>elated Projects
 <ul>
- <li><a href="https://github.com/GwtMaterialDesign/gwt-material-addins" >Addins 1.5.0</a></li>
- <li><a href="https://github.com/GwtMaterialDesign/gwt-material-themes" >Themes 1.5.0</a></li>
- <li><a href="https://github.com/GwtMaterialDesign/gwt-material-demo" >Demo 1.5.0</a></li>
- <li><a href="https://github.com/GwtMaterialDesign/gwt-material-template" >Starter 1.0</a></li>
- <li><a href="https://github.com/GwtMaterialDesign/gwt-material-patterns" >Patterns 1.0</a></li>
+ <li><a href="https://github.com/GwtMaterialDesign/gwt-material-addins" >Addins</a></li>
+ <li><a href="https://github.com/GwtMaterialDesign/gwt-material-themes" >Themes</a></li>
+ <li><a href="https://github.com/GwtMaterialDesign/gwt-material-demo" >Demo</a></li>
+ <li><a href="https://github.com/GwtMaterialDesign/gwt-material-template" >Starter</a></li>
+ <li><a href="https://github.com/GwtMaterialDesign/gwt-material-patterns" >Patterns</a></li>
 </ul>

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
@@ -1,5 +1,8 @@
 package gwt.material.design.client.ui;
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+
 /*
  * #%L
  * GwtMaterial
@@ -530,8 +533,32 @@ public class MaterialValueBox<T> extends MaterialWidget implements HasChangeHand
     }
 
     @Override
-    public void setFocus(boolean focused) {
-        valueBoxBase.setFocus(focused);
+    public void setFocus(final boolean focused) {
+    	Scheduler.get().scheduleDeferred(new ScheduledCommand() {
+			
+			@Override
+			public void execute() {
+				valueBoxBase.setFocus(focused);
+		        if(focused){
+		        	label.addStyleName("active");
+		        }else{
+		        	updateLabelActiveStyle();
+		        }
+			}
+		});
+    }
+    
+    /**
+     * Updates the style of the field label according to the field value
+     * if the field value is empty - null or "" - removes the label 'active' style
+     * else will add the 'active' style to the field label.
+     */
+    private void updateLabelActiveStyle(){
+    	if(this.valueBoxBase.getText()!=null && !this.valueBoxBase.getText().isEmpty()){
+    		label.addStyleName("active");
+    	}else{
+    		label.removeStyleName("active");
+    	}
     }
 
     @Override


### PR DESCRIPTION
 when setting the field focus programmatically using setFocus(true) then the user typed characters overlap with the placeholder #317 
the fix was done by adding the active style to the field label when focus value is true, otherwise it checks the field value and adds the active style if the value is not empty or null, if it is empty or null then the active style will be removed from the label.

the focus call was wrapped inside scheduler deferred call as recommended for the setFocus function.