### PR TITLE
Material Loader Bug fix

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialLoader.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialLoader.java
@@ -72,6 +72,7 @@ public class MaterialLoader {
             if(!(con instanceof RootPanel)) {
                 div.getElement().getStyle().setProperty("position", "absolute");
             }
+            div.setStyleName("valign-wrapper loader-wrapper");
             div.add(preLoader);
             con.add(div);
         } else {


### PR DESCRIPTION
   If you use MaterialLoader.showLoading() after MaterialLoader.showProgress() the loader have wrong style. This fix solve!