### PR TITLE
Fixed: Unable to add a CloseHandler to a MaterialModal

### DIFF
--- a/.utility/deploy.sh
+++ b/.utility/deploy.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 set -ev
-if [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "release_1.5.1" ]; then
+if [ "$TRAVIS_JDK_VERSION" == "oraclejdk7" ] && [ "$TRAVIS_PULL_REQUEST" == "false" ] && [ "$TRAVIS_BRANCH" == "release_1.6.0" ]; then
   echo "<settings><servers><server><id>ossrh</id><username>\${env.OSSRH_USER}</username><password>\${env.OSSRH_PASS}</password></server></servers></settings>" > ~/settings.xml
   mvn deploy --settings ~/settings.xml
 fi

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ We created <a href="http://gwtmaterialdesign.github.io/gwt-material-demo/apidocs
 You can find lists of features by version <a href="https://github.com/GwtMaterialDesign/gwt-material/wiki/Changelog">here</a>.
 
 ## Current Snapshot
-1.6.0-SNAPSHOT
+1.5.2-SNAPSHOT
 
 ### Migration
 [Migrating from 1.3 to 1.4](https://github.com/GwtMaterialDesign/gwt-material/wiki/Migrating-from-1.3-to-1.4)

--- a/gwt-material/pom.xml
+++ b/gwt-material/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>gwt-material-parent</artifactId>
     <groupId>com.github.gwtmaterialdesign</groupId>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>1.5.1</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/gwt-material/pom.xml
+++ b/gwt-material/pom.xml
@@ -25,6 +25,12 @@
       <version>4.11</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.maven.surefire</groupId>
+      <artifactId>surefire-junit4</artifactId>
+      <version>2.12.4</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/gwt-material/pom.xml
+++ b/gwt-material/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>gwt-material-parent</artifactId>
     <groupId>com.github.gwtmaterialdesign</groupId>
-    <version>1.5.1</version>
+    <version>1.6.0-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/gwt-material/src/main/java/gwt/material/design/client/base/AbstractIconButton.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/AbstractIconButton.java
@@ -32,12 +32,13 @@ import gwt.material.design.client.ui.MaterialIcon;
  */
 public abstract class AbstractIconButton extends AbstractButton implements HasIcon {
 
-    private MaterialIcon icon = new MaterialIcon();
+    private MaterialIcon icon;
 
     public AbstractIconButton(ButtonType type, String text, MaterialIcon icon) {
         super(type, text);
 
         this.icon = icon;
+        ensureIconAttached();
     }
 
     public AbstractIconButton(ButtonType type, String text) {
@@ -73,8 +74,9 @@ public abstract class AbstractIconButton extends AbstractButton implements HasIc
 
     @Override
     public void setIconType(IconType iconType) {
+        if(icon == null) { icon = new MaterialIcon(); }
         icon.setIconType(iconType);
-        insert(icon, 0);
+        ensureIconAttached();
     }
 
     @Override
@@ -105,5 +107,11 @@ public abstract class AbstractIconButton extends AbstractButton implements HasIc
     @Override
     public boolean isIconPrefix() {
         return icon.isIconPrefix();
+    }
+
+    public void ensureIconAttached() {
+        if(icon != null && !icon.isAttached()) {
+            insert(icon, 0);
+        }
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/base/AbstractIconButton.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/AbstractIconButton.java
@@ -32,7 +32,7 @@ import gwt.material.design.client.ui.MaterialIcon;
  */
 public abstract class AbstractIconButton extends AbstractButton implements HasIcon {
 
-    private MaterialIcon icon;
+    private MaterialIcon icon = new MaterialIcon();
 
     public AbstractIconButton(ButtonType type, String text, MaterialIcon icon) {
         super(type, text);
@@ -74,7 +74,6 @@ public abstract class AbstractIconButton extends AbstractButton implements HasIc
 
     @Override
     public void setIconType(IconType iconType) {
-        if(icon == null) { icon = new MaterialIcon(); }
         icon.setIconType(iconType);
         ensureIconAttached();
     }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialFAB.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialFAB.java
@@ -89,6 +89,10 @@ public class MaterialFAB extends MaterialWidget implements HasType<FABType>, Has
         }
     }
 
+    public boolean isToggle() {
+        return toggle;
+    }
+
     @Override
     public void setType(FABType type) {
         typeMixin.setType(type);

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
@@ -219,13 +219,11 @@ public class MaterialModal extends MaterialWidget implements HasType<ModalType>,
         this.opacity = opacity;
     }
 
-    @Override
-    public HandlerRegistration addCloseHandler(final CloseHandler<MaterialModal> handler) {
-        return this.addHandler(new CloseHandler<MaterialModal>() {
-            @Override
-            public void onClose(CloseEvent<MaterialModal> event) {
 
-            }
-        }, CloseEvent.getType());
+    @Override
+    public HandlerRegistration addCloseHandler(CloseHandler<MaterialModal> handler) {
+        return this.addHandler(handler, CloseEvent.getType());
     }
+
+
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTextArea.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTextArea.java
@@ -56,9 +56,7 @@ import java.util.Set;
 public class MaterialTextArea extends MaterialValueBox<String> {
 
     public enum ResizeRule {
-        NONE,
-        AUTO,
-        FOCUS
+        NONE, AUTO, FOCUS
     }
 
     private ResizeRule resizeRule = ResizeRule.NONE;

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTextArea.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialTextArea.java
@@ -20,9 +20,24 @@ package gwt.material.design.client.ui;
  * #L%
  */
 
+import com.google.gwt.core.client.Scheduler;
+import com.google.gwt.core.client.Scheduler.ScheduledCommand;
+import com.google.gwt.dom.client.Element;
+import com.google.gwt.event.dom.client.BlurEvent;
+import com.google.gwt.event.dom.client.BlurHandler;
+import com.google.gwt.event.dom.client.FocusEvent;
+import com.google.gwt.event.dom.client.FocusHandler;
+import com.google.gwt.event.logical.shared.AttachEvent;
+import com.google.gwt.event.logical.shared.AttachEvent.Handler;
 import com.google.gwt.event.logical.shared.ValueChangeEvent;
+import com.google.gwt.event.logical.shared.ValueChangeHandler;
+import com.google.gwt.event.shared.HandlerRegistration;
 import com.google.gwt.user.client.ui.TextArea;
 import gwt.material.design.client.constants.InputType;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 
 //@formatter:off
 
@@ -40,6 +55,17 @@ import gwt.material.design.client.constants.InputType;
 //@formatter:on
 public class MaterialTextArea extends MaterialValueBox<String> {
 
+    public enum ResizeRule {
+        NONE,
+        AUTO,
+        FOCUS
+    }
+
+    private ResizeRule resizeRule = ResizeRule.NONE;
+    private Set<HandlerRegistration> resizeHandlers;
+    private HandlerRegistration attachHandler;
+    private Integer originalHeight;
+
     public MaterialTextArea() {
         super(new TextArea());
         setType(InputType.TEXT);
@@ -47,13 +73,85 @@ public class MaterialTextArea extends MaterialValueBox<String> {
     }
 
     @Override
-    public void setValue(String value, boolean fireEvents) {
-        super.setValue(value,fireEvents);
+    public void setText(String text) {
+        super.setText(text);
 
-        if(fireEvents) {
-            ValueChangeEvent.fire(this, value);
+        if(resizeRule.equals(ResizeRule.AUTO)) {
+            triggerAutoResize();
         }
     }
 
+    public void triggerAutoResize() {
+        if(!valueBoxBase.isAttached()) {
+            if (attachHandler == null) {
+                attachHandler = valueBoxBase.addAttachHandler(new Handler() {
+                    @Override
+                    public void onAttachOrDetach(AttachEvent event) {
+                        if(event.isAttached()) {
+                            triggerAutoResize(valueBoxBase.getElement());
+                        }
+                    }
+                });
+            }
+        } else {
+            triggerAutoResize(valueBoxBase.getElement());
+        }
+    }
 
+    private native void triggerAutoResize(Element element) /*-{
+        $wnd.jQuery(document).ready(function() {
+            $wnd.jQuery(element).trigger('autoresize');
+        });
+    }-*/;
+
+    public ResizeRule getResizeRule() {
+        return resizeRule;
+    }
+
+    public void setResizeRule(ResizeRule resizeRule) {
+        this.resizeRule = resizeRule;
+        if(resizeHandlers == null) {
+            resizeHandlers = new HashSet<>();
+        }
+        removeResizeHandlers();
+
+        switch(resizeRule) {
+            case AUTO:
+                resizeHandlers.add(valueBoxBase.addValueChangeHandler(new ValueChangeHandler<String>() {
+                    @Override
+                    public void onValueChange(ValueChangeEvent<String> event) {
+                        triggerAutoResize();
+                    }
+                }));
+                break;
+            case FOCUS:
+                resizeHandlers.add(addFocusHandler(new FocusHandler() {
+                    @Override
+                    public void onFocus(FocusEvent event) {
+                        if(originalHeight == null) {
+                            originalHeight = valueBoxBase.getElement().getClientHeight();
+                        }
+                        triggerAutoResize();
+                    }
+                }));
+
+                resizeHandlers.add(addBlurHandler(new BlurHandler() {
+                    @Override
+                    public void onBlur(BlurEvent event) {
+                        if(originalHeight != null) {
+                            valueBoxBase.setHeight(originalHeight + "px");
+                        }
+                    }
+                }));
+                break;
+        }
+    }
+
+    private void removeResizeHandlers() {
+        if(resizeHandlers != null) {
+            for (HandlerRegistration handlerReg : resizeHandlers) {
+                handlerReg.removeHandler();
+            }
+        }
+    }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
@@ -12,9 +12,9 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
@@ -12,9 +12,9 @@ import com.google.gwt.core.client.Scheduler.ScheduledCommand;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -73,7 +73,6 @@ public class MaterialValueBox<T> extends MaterialWidget implements HasChangeHand
         HasAllGestureHandlers, HasAllKeyHandlers, HasAllMouseHandlers, HasAllTouchHandlers, HasError, HasInputType,
         HasPlaceholder, HasCounter, HasEditorErrors<T> {
 
-
     private String placeholder;
     private InputType type = InputType.TEXT;
     private boolean isValid = true;
@@ -82,31 +81,28 @@ public class MaterialValueBox<T> extends MaterialWidget implements HasChangeHand
 
     private Label label = new Label();
     private MaterialLabel lblName = new MaterialLabel();
-    @Ignore
-    protected ValueBoxBase<T> valueBoxBase;
+    @Ignore protected ValueBoxBase<T> valueBoxBase;
     private ValueBoxEditor<T> editor;
     private MaterialIcon icon = new MaterialIcon();
     private CounterMixin<MaterialValueBox<T>> counterMixin = new CounterMixin<>(this);
 
-    public class MaterialValueBoxEditor<T> extends ValueBoxEditor<T>{
+    public class MaterialValueBoxEditor<V> extends ValueBoxEditor<V> {
+        private final ValueBoxBase<V> valueBoxBase;
 
-        private final ValueBoxBase<T> valueBoxBase;
-
-        private MaterialValueBoxEditor(ValueBoxBase<T> valueBoxBase){
+        private MaterialValueBoxEditor(ValueBoxBase<V> valueBoxBase) {
             super(valueBoxBase);
-            this.valueBoxBase=valueBoxBase;
+            this.valueBoxBase = valueBoxBase;
         }
 
-
         @Override
-        public void setValue(T value) {
+        public void setValue(V value) {
             super.setValue(value);
             if (this.valueBoxBase.getText() != null && !this.valueBoxBase.getText().isEmpty()) {
                 label.addStyleName("active");
-            }else
+            } else {
                 label.removeStyleName("active");
+            }
         }
-
     }
 
     private final ErrorMixin<MaterialValueBox<T>, MaterialLabel> errorMixin = new ErrorMixin<>(this, lblError, valueBoxBase);
@@ -114,7 +110,7 @@ public class MaterialValueBox<T> extends MaterialWidget implements HasChangeHand
     public MaterialValueBox() {
         super(Document.get().createDivElement(), "input-field");
     }
-    
+
     public MaterialValueBox(ValueBoxBase<T> tValueBox) {
         this();
         initValueBox(tValueBox);
@@ -254,7 +250,7 @@ public class MaterialValueBox<T> extends MaterialWidget implements HasChangeHand
     @Override
     public ValueBoxEditor<T> asEditor() {
         if (editor == null) {
-            editor = new MaterialValueBoxEditor(valueBoxBase);
+            editor = new MaterialValueBoxEditor<>(valueBoxBase);
         }
         return editor;
     }
@@ -737,31 +733,30 @@ public class MaterialValueBox<T> extends MaterialWidget implements HasChangeHand
 
     @Override
     public void setFocus(final boolean focused) {
-	Scheduler.get().scheduleDeferred(new ScheduledCommand() {
-
-	    @Override
-	    public void execute() {
-		valueBoxBase.setFocus(focused);
-		if (focused) {
-		    label.addStyleName("active");
-		} else {
-		    updateLabelActiveStyle();
-		}
-	    }
-	});
+        Scheduler.get().scheduleDeferred(new ScheduledCommand() {
+            @Override
+            public void execute() {
+                valueBoxBase.setFocus(focused);
+                if (focused) {
+                    label.addStyleName("active");
+                } else {
+                    updateLabelActiveStyle();
+                }
+            }
+        });
     }
-    
+
     /**
      * Updates the style of the field label according to the field value if the
      * field value is empty - null or "" - removes the label 'active' style else
      * will add the 'active' style to the field label.
      */
     private void updateLabelActiveStyle() {
-	if (this.valueBoxBase.getText() != null && !this.valueBoxBase.getText().isEmpty()) {
-	    label.addStyleName("active");
-	} else {
-	    label.removeStyleName("active");
-	}
+        if (this.valueBoxBase.getText() != null && !this.valueBoxBase.getText().isEmpty()) {
+            label.addStyleName("active");
+        } else {
+            label.removeStyleName("active");
+        }
     }
 
     @Override

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.github.gwtmaterialdesign</groupId>
     <artifactId>gwt-material-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.5.1</version>
+    <version>1.6.0-SNAPSHOT</version>
 
     <modules>
         <module>gwt-material</module>
@@ -62,7 +62,7 @@
         <connection>scm:git:git@github.com:GwtMaterialDesign/gwt-material.git</connection>
         <developerConnection>scm:git:git@github.com:GwtMaterialDesign/gwt-material.git</developerConnection>
         <url>http://github.com/GwtMaterialDesign/gwt-material</url>
-        <tag>v1.5.1</tag>
+        <tag>v1.6.0-SNAPSHOT</tag>
     </scm>
 
     <licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <groupId>com.github.gwtmaterialdesign</groupId>
     <artifactId>gwt-material-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.5.2-SNAPSHOT</version>
+    <version>1.5.1</version>
 
     <modules>
         <module>gwt-material</module>
@@ -62,7 +62,7 @@
         <connection>scm:git:git@github.com:GwtMaterialDesign/gwt-material.git</connection>
         <developerConnection>scm:git:git@github.com:GwtMaterialDesign/gwt-material.git</developerConnection>
         <url>http://github.com/GwtMaterialDesign/gwt-material</url>
-        <tag>v1.5.2-SNAPSHOT</tag>
+        <tag>v1.5.1</tag>
     </scm>
 
     <licenses>


### PR DESCRIPTION
Fixed issue where one was unable to add a CloseHandler to a MaterialModal.

The CloseHandler passed in to addCloseHandler() was ignored and replaced with a new CloseHandler.
It was working in a previous commit, I've merely reverted this method. If my understanding of the functionality is incorrect, please ignore.