### PR TITLE
Fixed: Unable to add a CloseHandler to a MaterialModal

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
@@ -220,12 +220,8 @@ public class MaterialModal extends MaterialWidget implements HasType<ModalType>,
     }
 
     @Override
-    public HandlerRegistration addCloseHandler(final CloseHandler<MaterialModal> handler) {
-        return this.addHandler(new CloseHandler<MaterialModal>() {
-            @Override
-            public void onClose(CloseEvent<MaterialModal> event) {
-
-            }
-        }, CloseEvent.getType());
+    public HandlerRegistration addCloseHandler(CloseHandler<MaterialModal> handler) {
+        return this.addHandler(handler, CloseEvent.getType());
     }
+
 }


### PR DESCRIPTION
Fixed issue where one was unable to add a CloseHandler to a MaterialModal.

The CloseHandler passed in to addCloseHandler() was ignored and replaced with a new CloseHandler.
It was working in a previous commit, I've merely reverted this method. If my understanding of the functionality is incorrect, please ignore.