### PR TITLE
Added support for helper texts alongside error and success messages.

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/base/HasError.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/HasError.java
@@ -31,6 +31,8 @@ public interface HasError {
     void setError(String error);
 
     void setSuccess(String success);
+    
+    void setHelperText(String helperText);
 
     void clearErrorOrSuccess();
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/base/mixin/ErrorMixin.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/mixin/ErrorMixin.java
@@ -29,9 +29,10 @@ import gwt.material.design.client.base.HasError;
  */
 public class ErrorMixin<T extends UIObject & HasError, H extends UIObject & HasText>
         extends AbstractMixin<T> implements HasError {
-
+    
     private H textObject;
     private UIObject target;
+    private String helperText;
 
     public ErrorMixin(final T widget, final H textObject, UIObject target) {
         super(widget);
@@ -44,6 +45,7 @@ public class ErrorMixin<T extends UIObject & HasError, H extends UIObject & HasT
     public void setError(String error) {
         textObject.setText(error);
         textObject.addStyleName("field-error-label");
+        textObject.removeStyleName("field-helper-label");
         textObject.removeStyleName("field-success-label");
         if(target != null) {
             target.addStyleName("field-error");
@@ -56,6 +58,7 @@ public class ErrorMixin<T extends UIObject & HasError, H extends UIObject & HasT
     public void setSuccess(String success) {
         textObject.setText(success);
         textObject.addStyleName("field-success-label");
+        textObject.removeStyleName("field-helper-label");
         textObject.removeStyleName("field-error-label");
         if(target != null) {
             target.addStyleName("field-success");
@@ -63,16 +66,28 @@ public class ErrorMixin<T extends UIObject & HasError, H extends UIObject & HasT
         }
         textObject.setVisible(true);
     }
+    
+    @Override
+    public void setHelperText(String helperText) {
+        this.helperText = helperText;
+        clearErrorOrSuccess();
+    }
 
     @Override
     public void clearErrorOrSuccess() {
-        textObject.setText("");
+        textObject.setText(helperText == null ? "" : helperText);
+        if (helperText != null){
+            textObject.addStyleName("field-helper-label");
+        }
+        else {
+            textObject.removeStyleName("field-helper-label");
+        }
         textObject.removeStyleName("field-error-label");
         textObject.removeStyleName("field-success-label");
         if(target != null) {
             target.removeStyleName("field-error");
             target.removeStyleName("field-success");
         }
-        textObject.setVisible(false);
+        textObject.setVisible(helperText != null);
     }
 }

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
@@ -400,6 +400,11 @@ public class MaterialDatePicker extends MaterialWidget implements HasGrid, HasEr
         lblName.setStyleName("green-text");
         dateInput.addStyleName("valid");
     }
+    
+    @Override
+    public void setHelperText(String helperText) {
+        errorMixin.setHelperText(helperText);
+    }
 
     @Override
     public void clearErrorOrSuccess() {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialRange.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialRange.java
@@ -223,6 +223,11 @@ public class MaterialRange extends MaterialWidget implements HasChangeHandlers, 
     public void setSuccess(String success) {
         errorMixin.setSuccess(success);
     }
+    
+    @Override
+    public void setHelperText(String helperText) {
+        errorMixin.setHelperText(helperText);
+    }
 
     @Override
     public void clearErrorOrSuccess() {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSwitch.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialSwitch.java
@@ -223,6 +223,11 @@ public class MaterialSwitch extends MaterialWidget implements HasValue<Boolean>,
     public void setSuccess(String success) {
         errorMixin.setSuccess(success);
     }
+    
+    @Override
+    public void setHelperText(String helperText) {
+        errorMixin.setHelperText(helperText);
+    }
 
     @Override
     public void clearErrorOrSuccess() {

--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialValueBox.java
@@ -643,6 +643,11 @@ public class MaterialValueBox<T> extends MaterialWidget implements HasChangeHand
         lblName.setStyleName("green-text");
         valueBoxBase.getElement().addClassName("valid");
     }
+    
+    @Override
+    public void setHelperText(String helperText) {
+        errorMixin.setHelperText(helperText);
+    }
 
     @Override
     public void clearErrorOrSuccess() {

--- a/gwt-material/src/main/resources/gwt/material/design/public/css/overridecss.css
+++ b/gwt-material/src/main/resources/gwt/material/design/public/css/overridecss.css
@@ -90,6 +90,11 @@ ul li button.btn-floating {
 .field-success-label {
 	color: #4CAF50 !important;
 }
+.field-helper-label {
+	color: #9E9E9E !important;
+	font-size: 12px;
+	opacity: 1 !important;
+}
 
 .field-success, .field-success-picker input {
 	border-bottom: 1px solid #4CAF50 !important;


### PR DESCRIPTION
The helper text is a longer hint added to a form component, to show the user how to complete the field. The spec is described here: https://material.google.com/patterns/errors.html#errors-user-input-errors

![screenshot from 2016-07-10 17 30 23](https://cloud.githubusercontent.com/assets/7464735/16715911/1b065460-46c4-11e6-9885-7bb40e8e5709.png)

The HasError interface was modified to have a `setHelperText(String)` method. When setting an error or success message, the helper text is overridden. The `clearErrorOrSuccess()` method reverts the info label to the helper text, if one was provided by the user.

This is the base commit for the gwt-material project. I also changed the addins and the demo projects to follow the changes on the interface.