### PR TITLE
Fix issues #388 MaterialListBox: enabled state cannot be changed

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListBox.java
@@ -711,6 +711,9 @@ public class MaterialListBox extends MaterialWidget implements HasId, HasGrid, H
     @Override
     public void setEnabled(boolean enabled) {
         listBox.setEnabled(enabled);
+        if (initialized) {
+            initializeMaterial(listBox.getElement());
+        }
     }
 }
 


### PR DESCRIPTION
Fix issues #388, When user setEnabled need call initializeMaterial(listBox.getElement());
to change the ListBox style.