### PR TITLE
Fix issues #388 MaterialListBox: enabled state cannot be changed

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListValueBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListValueBox.java
@@ -771,6 +771,10 @@ public class MaterialListValueBox<T> extends MaterialWidget implements HasId, Ha
     @Override
     public void setEnabled(boolean enabled) {
         listBox.setEnabled(enabled);
+         if (initialized) {
+            // reinitialize
+            initializeMaterial(listBox.getElement());
+        }
     }
 
     @Override


### PR DESCRIPTION
Fix issues #388 MaterialListBox: enabled state cannot be changed
When user call the setEnable method need to call initializeMaterial.