### PR TITLE
Modal dialog rework

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialModal.java
@@ -32,9 +32,6 @@ import gwt.material.design.client.constants.CssName;
 import gwt.material.design.client.constants.ModalType;
 import gwt.material.design.client.js.JsModalOptions;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import static gwt.material.design.client.js.JsMaterialElement.$;
 
 //@formatter:off
@@ -82,48 +79,6 @@ import static gwt.material.design.client.js.JsMaterialElement.$;
 public class MaterialModal extends MaterialWidget implements HasType<ModalType>, HasInOutDurationTransition,
         HasDismissible, HasCloseHandlers<MaterialModal>, HasOpenHandlers<MaterialModal> {
 
-    static class ModalManager {
-        private static List<MaterialModal> modals;
-        private static final int index = 1010;
-
-        /**
-         * Registers the modal and added to static modal lists
-         */
-        public static void register(MaterialModal modal) {
-            if (modals == null) {
-                modals = new ArrayList<>();
-            }
-            modals.add(modal);
-            resetZIndex();
-        }
-
-        /**
-         * Unregisters the modal and removed it from static modal lists
-         */
-        public static void unregister(MaterialModal modal) {
-            if (modals == null) {
-                modals = new ArrayList<>();
-            }
-            if (modals.remove(modal)) {
-                resetZIndex();
-            }
-        }
-
-        /**
-         * Need to reset every time we have register / unregister process
-         */
-        protected static void resetZIndex() {
-            int i = index;
-            for (MaterialModal modal : modals) {
-                modal.setDepth(i++);
-                // Fixed Lean Overlay z index - must recalculate value based on number of modals plus 1
-                // to make it behind the modal z index.
-                $(".lean-overlay").css("zIndex", String.valueOf(modal.getDepth() - 1));
-            }
-
-        }
-    }
-
     private final CssTypeMixin<ModalType, MaterialModal> typeMixin = new CssTypeMixin<>(this);
     private int inDuration = 300;
     private int outDuration = 200;
@@ -133,13 +88,6 @@ public class MaterialModal extends MaterialWidget implements HasType<ModalType>,
 
     public MaterialModal() {
         super(Document.get().createDivElement(), CssName.MODAL);
-    }
-
-    @Override
-    protected void onUnload() {
-        super.onUnload();
-
-        close(false, false);
     }
 
     /**
@@ -204,8 +152,8 @@ public class MaterialModal extends MaterialWidget implements HasType<ModalType>,
         options.dismissible = dismissible;
         options.in_duration = inDuration;
         options.out_duration = outDuration;
+        options.complete = () -> onNativeClose(true, true);
         $(e).openModal(options);
-        ModalManager.register(this);
         if (fireEvent) {
             OpenEvent.fire(this, this);
         }
@@ -256,7 +204,6 @@ public class MaterialModal extends MaterialWidget implements HasType<ModalType>,
      */
     public void close(boolean autoClosed, boolean fireEvent) {
         close(getElement(), autoClosed, fireEvent);
-        ModalManager.unregister(this);
     }
 
     protected void close(Element e, boolean autoClosed, boolean fireEvent) {

--- a/gwt-material/src/main/resources/gwt/material/design/client/resources/js/materialize-0.97.5.js
+++ b/gwt-material/src/main/resources/gwt/material/design/client/resources/js/materialize-0.97.5.js
@@ -673,7 +673,7 @@ if ($) {
     $('.dropdown-button').dropdown();
   });
 }( jQuery ));;(function($) {
-    var _stack = 0,
+    var _stack = new Array(),
     _lastID = 0,
     _generateID = function() {
       _lastID++;
@@ -697,11 +697,14 @@ if ($) {
       overlayID = _generateID(),
       $modal = $(this),
       $overlay = $('<div class="lean-overlay"></div>'),
-      lStack = (++_stack);
-
+      lStack = (_stack.length == 0 ? 1 : _stack[_stack.length - 1] + 1);
+      
+      _stack.push(lStack);
+      
       // Store a reference of the overlay
       $overlay.attr('id', overlayID).css('z-index', 1000 + lStack * 2);
       $modal.data('overlay-id', overlayID).css('z-index', 1000 + lStack * 2 + 1);
+      $modal.data('stack-ordinal', lStack);
 
       $("body").append($overlay);
 
@@ -775,6 +778,7 @@ if ($) {
         complete: undefined
       },
       $modal = $(this),
+      lStack = $modal.data('stack-ordinal'),
       overlayID = $modal.data('overlay-id'),
       $overlay = $('#' + overlayID);
 
@@ -804,7 +808,7 @@ if ($) {
               options.complete();
             }
             $overlay.remove();
-            _stack--;
+           	_stack.splice(_stack.indexOf(lStack), 1);
           }
         });
       }
@@ -821,7 +825,7 @@ if ($) {
                 options.complete();
               }
               $overlay.remove();
-              _stack--;
+              _stack.splice(_stack.indexOf(lStack), 1);
             }
           }
         );

--- a/gwt-material/src/test/java/gwt/material/design/client/ui/MaterialModalTest.java
+++ b/gwt-material/src/test/java/gwt/material/design/client/ui/MaterialModalTest.java
@@ -41,21 +41,6 @@ public class MaterialModalTest extends MaterialWidgetTest {
         checkType(modal);
         checkDimissible(modal);
         checkDuration(modal);
-        checkMultipleModalZIndexes();
-    }
-
-    protected void checkMultipleModalZIndexes() {
-        int initialZIndex = 1010;
-        for (int i = 0; i <= 5; i++) {
-            MaterialModal modal = new MaterialModal();
-            RootPanel.get().add(modal);
-            modal.open();
-            // Check For Modal Z indexes
-            assertEquals(modal.getElement().getStyle().getZIndex(), String.valueOf(initialZIndex + i));
-            // Check For Modal Lean Overlay Z indexes
-            assertEquals($(".lean-overlay").css("zIndex"), String.valueOf(modal.getDepth() - 1));
-        }
-
     }
 
     protected void checkDuration(MaterialModal modal) {


### PR DESCRIPTION
As discussed in #620, I'm proposing substituting MaterialModal.ModalManager with materialize.js's own modal management which obviously fixed issues that ModalManager was meant to patch (like #257).

I would like to note that last commit considering ModalManager fixed original issue that I was initially trying to solve, but during my tests I came to conclusion that the same effect can be accomplished with complete removal of ModalManager. So I'm proposing this patch as a simplification via code reduction.

As I was at it, I also implemented my proposal for better stack management inside materialize.js by substituting _stack counter with array that behaves like real stack which memorizes highest stack counter instead of just keeping reference of number of modals opened. This allows for out-of-order modal closing. I'm not sure that this should be submitted as patch here instead of original materialize repo, but since this is just a proposal, we can discuss this.

One more thing fixed in MaterialModal is preventing multiple close events (more specifically, multiple calls to JsMaterialElement.closeModal) by removing MaterialModal.onUnload. I couldn't find a reason for calling close from within onUnload, but if I missed something and it should be there, it should at least check if modal was already closed and not call JsMaterialElement.closeModal in that case. Note that this is wrong from materialize.js perspective, but it was masked by MaterialModal's forcing of zIndex attribute. I tried to include guards from multiple modal closing in materialize.js, but my JavaScript-fu was not that strong :)

Last issue fixed is not throwing CloseEvent in case of closing dismissable modal via clicking on overlay or by pressing Esc key. It turned out that JsModalOptions.complete that is passed in **open**Modal is necessary after all for this to work (it was removed in some o yesterdays commits). I reintroduce it and now CloseEvents are fired again.

Finally, I'm sorry for proposing all this modifications in single pull request instead of splitting them in separate ones, but it seemed to me that they are all related. If needed, I could make separate PR for each  modifications described.