### PR TITLE
Fix for issue #628 ListBox there is no default null value. Always first from the list is selected.

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListValueBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListValueBox.java
@@ -80,6 +80,7 @@ public class MaterialListValueBox<T> extends AbstractValueWidget<T> implements J
     protected final List<T> values = new ArrayList<>();
     private KeyFactory<T, String> keyFactory = new AllowBlankKeyFactory();
     private MaterialLabel errorLabel = new MaterialLabel();
+    private boolean loaded = false;
 
     private ToggleStyleMixin<ListBox> toggleOldMixin;
     private ReadOnlyMixin<MaterialListValueBox<T>, ListBox> readOnlyMixin;
@@ -126,6 +127,10 @@ public class MaterialListValueBox<T> extends AbstractValueWidget<T> implements J
             }
             return true;
         });
+        loaded = true;
+        if (isAllowBlank()) {
+            addBlankItemIfNeeded();
+        }
     }
 
     @Override
@@ -800,9 +805,17 @@ public class MaterialListValueBox<T> extends AbstractValueWidget<T> implements J
     }
 
     protected void addBlankItemIfNeeded() {
-        int idx = getIndex(null);
-        if (idx < 0) {
-            addItem(null, true);
+        if (loaded) {
+            int idx = getIndex(null);
+            if (idx < 0) {
+                ArrayList<T> previous = new ArrayList<>(values);
+                values.clear();
+                values.add(null);
+                values.addAll(previous);
+                listBox.insertItem(BLANK_VALUE_TEXT, 0);
+                setSelectedIndex(-1);
+                reload();
+            }
         }
     }
 


### PR DESCRIPTION
I discovered there are some cases in the code of my previous pull request (#715) where the underlying Javascript is not fully initialized when the blank option is added causing an exception. These changes fix this problem. It now functions correctly in all use cases I have tested.
