### PR TITLE
MaterialDatePicker setValue/getValue fixed if not attached

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialDatePicker.java
@@ -385,16 +385,21 @@ public class MaterialDatePicker extends AbstractValueWidget<Date> implements JsL
 
     @Override
     public Date getValue() {
-        return getPickerDate();
+        if (isAttached()) {
+            return getPickerDate();
+        }
+        else {
+            return this.date;
+        }
     }
 
     @Override
     public void setValue(Date value, boolean fireEvents) {
+        this.date = value;
         if (value == null) {
             clear();
             return;
         }
-        this.date = value;
         if (isAttached()) {
             suppressChangeEvent = !fireEvents;
             setPickerDate(JsDate.create((double) value.getTime()), pickatizedDateInput);
@@ -649,6 +654,7 @@ public class MaterialDatePicker extends AbstractValueWidget<Date> implements JsL
 
     @Override
     public void clear() {
+        this.date = null;
         dateInput.clear();
         if (getPicker() != null) {
             getPicker().set("select", null);

--- a/gwt-material/src/test/java/gwt/material/design/client/ui/MaterialDatePickerTest.java
+++ b/gwt-material/src/test/java/gwt/material/design/client/ui/MaterialDatePickerTest.java
@@ -275,8 +275,20 @@ public class MaterialDatePickerTest extends AbstractValueWidgetTest<MaterialDate
     }
 
     public void testDateValue() {
+        // UiBinder
         // given
-        MaterialDatePicker datePicker = getWidget();
+        MaterialDatePicker datePicker = getWidget(false);
+
+        // when / then
+        datePicker.setValue(DATE);
+        assertEquals(datePicker.getValue(), DATE);
+
+        datePicker.setValue(null);
+        assertEquals(datePicker.getValue(), null);
+
+        // Standard
+        // given
+        attachWidget();
 
         boolean[] isValueChanged = {false};
         datePicker.addValueChangeHandler(event -> isValueChanged[0] = true);
@@ -290,6 +302,9 @@ public class MaterialDatePickerTest extends AbstractValueWidgetTest<MaterialDate
 
         datePicker.setValue(DATE);
         assertEquals(datePicker.getValue(), DATE);
+
+        datePicker.setValue(null);
+        assertEquals(datePicker.getValue(), null);
 
         datePicker.setValue(DATE);
         datePicker.setValue(DATE, false);


### PR DESCRIPTION
closes #740 MaterialDatePicker only works correct with Editor Framework when it is attached to the View