### PR TITLE
Fixed Redundant #reload, #setSelectedIndexInternal

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListValueBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialListValueBox.java
@@ -715,7 +715,9 @@ public class MaterialListValueBox<T> extends AbstractValueWidget<T> implements J
      * @param index the index of the item to be selected
      */
     public void setSelectedIndex(int index) {
-        index += getIndexOffset();
+        if (index >= 0) {
+            index += getIndexOffset();
+        }
         setSelectedIndexInternal(index);
     }
 
@@ -900,8 +902,7 @@ public class MaterialListValueBox<T> extends AbstractValueWidget<T> implements J
                 values.add(null);
                 values.addAll(previous);
                 listBox.insertItem(BLANK_VALUE_TEXT, 0);
-                setSelectedIndex(-1);
-                reload();
+                setSelectedIndexInternal(-1);
             }
         }
     }


### PR DESCRIPTION
 - removed redundant #reload() call
 - for internal calls #setSelectedIndexInternal(int) is preferred over #setSelectedIndex(int)
 - #setSelectedIndex(int) should not try to "correct" the input value when it is equal to -1