### PR TITLE
Issue #996

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/base/mixin/StatusTextMixin.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/base/mixin/StatusTextMixin.java
@@ -61,7 +61,7 @@ public class StatusTextMixin<T extends UIObject & HasStatusText, H extends UIObj
     @Override
     public void setErrorText(String errorText) {
         clearSuccessText();
-        clearHelperText();
+        hideHelperText();
         updateStatusDisplay(StatusDisplayMixin.StatusType.ERROR);
 
         if (textObject != null) {
@@ -85,7 +85,7 @@ public class StatusTextMixin<T extends UIObject & HasStatusText, H extends UIObj
     @Override
     public void setSuccessText(String successText) {
         clearErrorText();
-        clearHelperText();
+        hideHelperText();
         updateStatusDisplay(StatusDisplayMixin.StatusType.SUCCESS);
 
         if (textObject != null) {
@@ -173,6 +173,11 @@ public class StatusTextMixin<T extends UIObject & HasStatusText, H extends UIObj
 
     @Override
     public void clearHelperText() {
+        helperText="";
+        hideHelperText();
+    }
+
+    private void hideHelperText() {
         if (textObject != null) {
             textObject.setText("");
             textObject.setVisible(false);


### PR DESCRIPTION
changed clearHelperText() to set local variable helperText to empty string and then call hideHelperText()
private method hideHelperText() contains the code from the previous clearHelperText method and is called instead of clearHelperText() from setErrorText() and setSuccessText()

This ensures that helperText will be reinstated when error or success text is removed (eg after successful validation) unless it has been cleared