### PR TITLE
npe fixed in MaterialToast.isOpen()

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialToast.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialToast.java
@@ -200,6 +200,9 @@ public class MaterialToast {
         String id = getId();
         if (id != null && !id.isEmpty()) {
             Widget toast = RootPanel.get(id);
+            if(toast == null){
+                return false;
+            }
             return toast.isAttached() && toast.isVisible();
         }
         return false;


### PR DESCRIPTION
If a toast was previously closed and afterwards you check if it is open a null pointer exception is thrown.