### PR TITLE
Fixed IndexOutOfBoundsException in MaterialCollapsible

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsible.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialCollapsible.java
@@ -254,7 +254,7 @@ public class MaterialCollapsible extends MaterialWidget
     public void setActive(int index, boolean active) {
         activeIndex = index;
         if (isAttached()) {
-            if (index <= getWidgetCount()) {
+            if (index < getWidgetCount()) {
                 if (index > 0) {
                     activeWidget = getWidget(index);
                     if (activeWidget != null && activeWidget instanceof MaterialCollapsibleItem) {


### PR DESCRIPTION
This should fix an IndexOutOfBoundsException that occurs when executing setActive with index 1 if there is only one item.

This error started occuring since this commit afaik: https://github.com/GwtMaterialDesign/gwt-material/commit/60d3d2137aa45e4af9f3b5501d774f86e3d364e8