### PR TITLE
Fix: avoid precision loss for Long values by parsing as String instead of using a JavaScript Number

### DIFF
--- a/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialLongBox.java
+++ b/gwt-material/src/main/java/gwt/material/design/client/ui/MaterialLongBox.java
@@ -57,10 +57,39 @@ public class MaterialLongBox extends MaterialNumberBox<Long> {
     }
 
     @Override
-    protected Long parseNumber(double number) {
-        if (Double.isNaN(number)) {
+    public Long getValue() {
+        final String value = valueBoxBase.getText();
+        if ((value == null) || value.isEmpty()) {
             return null;
         }
-        return (long) Math.rint(number);
+
+        try {
+            return Long.parseLong(value);
+        }
+        catch (final NumberFormatException i_exception) {
+            return null;
+        }
+    }
+
+    /**
+     * @deprecated JavaScript Number uses IEEE-754 double precision and cannot
+     *             reliably represent 64-bit integer values. Use {@link #getValue()} instead.
+     */
+    @Override
+    @Deprecated
+    public Double getValueAsNumber() {
+        return super.getValueAsNumber();
+    }
+
+    /**
+     * @deprecated Parsing through double leads to precision loss for large values.
+     *             This method should not be used for Long values.
+     */
+    @Override
+    @Deprecated
+    protected Long parseNumber(final double i_number) {
+        throw new UnsupportedOperationException(
+            "Double-based parsing is not supported for Long values."
+        );
     }
 }


### PR DESCRIPTION
MaterialNumberBox currently relies on JavaScript Number parsing, which uses
IEEE-754 double precision and cannot accurately represent 64-bit integer values.

This leads to precision loss when working with Long values greater than 2^53-1.

This PR introduces a Long-safe implementation that:
- Reads the input value as String
- Parses using Long.parseLong()
- Avoids any JavaScript numeric conversion

Additionally:
- Deprecated double-based parsing methods
- Added explicit documentation about precision limitations

This approach preserves full 64-bit integer accuracy without breaking existing APIs.